### PR TITLE
Enable edit this page link on SDK pages

### DIFF
--- a/docs/sdk/android.mdx
+++ b/docs/sdk/android.mdx
@@ -4,7 +4,6 @@ sidebar_label: Android
 title: Android SDK
 id: android
 description: Documentation for Android SDK
-custom_edit_url: null # Note: This hides the edit this page button
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/sdk/capacitor.mdx
+++ b/docs/sdk/capacitor.mdx
@@ -4,7 +4,6 @@ sidebar_label: Capacitor
 title: Capacitor Plugin
 id: capacitor
 description: Documentation for Capacitor Plugin
-custom_edit_url: null # Note: This hides the edit this page button
 ---
 
 This is the documentation for the Capacitor plugin. Before integrating, read the [native SDK documentation](/sdk) to familiarize yourself with the platform.

--- a/docs/sdk/cordova.mdx
+++ b/docs/sdk/cordova.mdx
@@ -4,7 +4,6 @@ sidebar_label: Cordova
 title: Cordova Plugin
 slug: cordova
 description: Documentation for Cordova Plugin
-custom_edit_url: null # Note: This hides the edit this page button
 ---
 
 This is the documentation for the Cordova plugin. Before integrating, read the [native SDK documentation](/sdk) to familiarize yourself with the platform.

--- a/docs/sdk/flutter.mdx
+++ b/docs/sdk/flutter.mdx
@@ -4,7 +4,6 @@ sidebar_label: Flutter
 title: Flutter Package
 slug: flutter
 description: Documentation for Flutter Package
-custom_edit_url: null # Note: This hides the edit this page button
 ---
 
 This is the documentation for the Flutter package. Before integrating, read the [native SDK documentation](/sdk) to familiarize yourself with the platform.

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -4,7 +4,6 @@ sidebar_label: iOS
 title: iOS SDK
 id: ios
 description: Documentation for iOS SDK
-custom_edit_url: null # Note: This hides the edit this page button
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -4,7 +4,6 @@ sidebar_label: React Native
 title: React Native SDK
 id: react-native
 description: Documentation for React Native SDK
-custom_edit_url: null # Note: This hides the edit this page button
 ---
 
 This is the documentation for the React Native module. Before integrating, read the [native SDK documentation](/sdk) to familiarize yourself with the platform.

--- a/docs/sdk/sdk.mdx
+++ b/docs/sdk/sdk.mdx
@@ -4,7 +4,6 @@ sidebar_label: Overview
 id: sdk-overview
 slug: /sdk
 title: SDK Reference
-custom_edit_url: null # Note: This hides the edit this page button
 ---
 
 import LinkCard from '../../src/components/LinkCard'

--- a/docs/sdk/tracking.mdx
+++ b/docs/sdk/tracking.mdx
@@ -1,7 +1,6 @@
 ---
 sidebar_label: Tracking
 title: Tracking Options Reference
-custom_edit_url: null # Note: This hides the edit this page button
 ---
 
 For background tracking, the SDK supports custom tracking options as well as three presets: **`EFFICIENT`**, **`RESPONSIVE`**, and **`CONTINUOUS`**.

--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -4,7 +4,6 @@ sidebar_label: Web
 title: Web SDK
 id: web
 description: Documentation for Web SDK
-custom_edit_url: null # Note: This hides the edit this page button
 ---
 
 This is the documentation for the web JavaScript SDK. Before integrating, read the [native SDK documentation](/sdk) to familiarize yourself with the platform.


### PR DESCRIPTION
## Changes
Removes Frontmatter that hides `Edit this page` at the bottom of SDK pages