### PR TITLE
Only add right border to logo on wider resolutions

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -216,8 +216,14 @@ strong {
 .navbar__brand {
   height: 100%;
   width: calc(var(--doc-sidebar-width) - var(--ifm-navbar-padding-horizontal));
-  border-right: 1px solid var(--ifm-toc-border-color);
   margin-right: 0;
+}
+
+/* Responsive Styling for Navbar; these links should appear in the hamburger menu */
+@media (min-width: 996px) {
+  .navbar__brand {
+    border-right: 1px solid var(--ifm-toc-border-color);
+  }
 }
 
 .navbar__logo {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -188,7 +188,7 @@ h2 {
   display: grid;
   grid-template-columns: 33% 33% 33%;
   grid-gap: 30px;
-  margin-right: 30px;
+  margin-right: 60px;
 }
 
 .logo {


### PR DESCRIPTION
## Summary
Moving a CSS rule to only apply on wider screen sizes

## Screenshots
Before `.navbar__brand` css change:
![image](https://user-images.githubusercontent.com/1566055/121256520-a4b7b400-c87a-11eb-8dd9-dbf900c2977d.png)

After `.navbar__brand` css change:
![image](https://user-images.githubusercontent.com/1566055/121256557-aed9b280-c87a-11eb-8228-cadc39906fd1.png)

Before `.deck` css change:
![image](https://user-images.githubusercontent.com/1566055/121256464-949fd480-c87a-11eb-8fbd-ac1139112d07.png)

After `.deck` css change:
![image](https://user-images.githubusercontent.com/1566055/121256404-8487f500-c87a-11eb-92d1-a1327cdfde94.png)
