### PR TITLE
Add PR Template for docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+  Thanks for submitting a pull request!
+  Please provide enough information so that others can review your pull request.
+-->
+
+## What?
+<!--
+  Please explain what problem your pull request is trying to solve.
+  Are there any linked issues?
+-->
+
+## Why?
+<!--
+  Explain the **motivation** for making this change.
+-->
+
+## How?
+<!--
+  If you made a functional change (as opposed to just a content change):
+    - How did you implement this change?
+    - What decisions did you make?
+-->
+
+## Screenshots (optional)
+<!--
+  If you made a UI change, please include any screenshots/videos!
+-->
+
+## Anything Else? (optional)
+<!--
+  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
+-->


### PR DESCRIPTION
## What?
Adding a PR Template to our Documentation Repo

## Why?
In order to provide more context for reviewers and guide contributors to add details :)

## How?
- Added a PR Template to `.github` per https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository