### PR TITLE
Implement most of Beryl's feedback for docs

### DIFF
--- a/src/components/ScrollToTopButton.module.css
+++ b/src/components/ScrollToTopButton.module.css
@@ -1,14 +1,16 @@
 .ScrollToTopButton {
   position: fixed;
-  width: 32px;
-  height: 32px;
-  bottom: 40px;
-  right: 40px;
+  width: 2.5rem;
+  height: 40px;
+  bottom: 2rem;
+  right: 2rem;
   box-shadow: 0px 4px 12px rgba(23, 60, 86, 0.1);
   background: transparent;
-  border: none;
+  border: 1px solid var(--radar-gray-2);
   border-radius: 4px;
   cursor: pointer;
+  transition-property: color,background;
+  transition-timing-function: var(--ifm-transition-timing-default);
 }
 
 .ScrollToTopButton:hover {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -213,6 +213,10 @@ strong {
   color: var(--ifm-heading-color);
 }
 
+.navbar__toggle {
+  margin-right: 1rem;
+}
+
 .navbar__brand {
   height: 100%;
   width: calc(var(--doc-sidebar-width) - var(--ifm-navbar-padding-horizontal));
@@ -234,7 +238,7 @@ strong {
 
 .menu {
   padding: 0 !important;
-  margin-top: 15px;
+  padding-top: 15px;
   font-weight: var(--ifm-font-weight-normal);
 }
 
@@ -324,7 +328,7 @@ strong {
 .alert {
   margin: 1rem 0 2rem;
   padding: .5rem 1rem .5rem 3rem;
-font-size: 1rem;
+  font-size: 1rem;
   font-weight: 400;
   line-height: 1.6;
   /* Use variables for borders */
@@ -337,6 +341,15 @@ font-size: 1rem;
   background-repeat: no-repeat;
 }
 
+.alert a {
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.alert a:hover {
+  text-decoration: underline;
+}
+
 .alert-warning {
   background-color: #fff1e4;
   border-color: rgba(109,51,0,.25);
@@ -344,11 +357,21 @@ font-size: 1rem;
   background-image: url(/static/img/warningIcon.svg);
 }
 
+.alert-warning a,
+.alert-warning strong {
+  color: #6d3300;
+}
+
 .alert-info {
   background-color: #dcedff;
   border-color: rgba(0,56,117,.25);
   color: #003875;
   background-image: url(/static/img/infoIcon.svg);
+}
+
+.alert-info a,
+.alert-info strong {
+  color: #003875;
 }
 
 .chains-logo {
@@ -403,4 +426,22 @@ table th {
 
 table th, table td {
   max-width: 230px;
+}
+
+/* Tab Item Overrides */
+
+.tabs__item {
+  border-bottom-width: 2px;
+  padding: 0.5rem;
+  margin-right: 0.5rem;
+  color: var(--radar-gray-4);
+}
+
+.tabs__item--active {
+  border-bottom-color: var(--radar-gray-6);
+  color: var(--radar-gray-6);
+}
+
+.tabs__item:hover {
+  background: var(--radar-gray-1);
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
These were most of @berylw's callouts from https://www.notion.so/radarlabs/Feedback-from-Beryl-70bece6c8e654c8489659a8f7ad72dbb#b3b6373ee185484aac8b64f4a9a0653b

## Why?
Because Beryl caught the gaps in my thinking

## Beryl's Feedback List
- **Content**
    - [x]  Tweak code block tab styling to be more consistent with our other tabs
        - [x]  Change hover background color to `#F6F9FC` (`$gray1`)
        - [x]  Change active tab text color and bottom border color to `#173C56` (`$gray6`)
        - [x]  Decrease bottom border stroke from `3px` to `2px`
        - [x]  Change tab padding to `padding: 0.5rem`
        - [x]  Change tab margin to `margin-right: 0.5rem`
        - [x]  Change inactive tab text color to `#97A8B4` (`$gray4`)
    - [x]  Alert styling
        - [x]  Links and strong text should be `#6d3300` (`$darkOrange`) and `#003875` (`$darkRoyal`) for warning and info alerts, respectively
        - [x]  Set `text-decoration: none` and `font-weight: 600` on links, but keep the underline on hover
- **Narrow width layout**
    - [x]  Increase padding to right of docs logo to `1rem`
    - [x]  Seems to be a `margin-top: 15px` on the docs nav when both the header and sidebar nav are open, not sure if intentional but padding might work better here?
- **Miscellaneous**
    - [x]  Back to top button styling
        - [x]  Increase width and height to `2.5rem` / `40px`
        - [x]  Add `border: 1px solid #E6EDF2` (`$gray2`)
        - [x]  Set right and bottom to `2rem`
        - [x]  Add background hover transition, I think it'd be something like `transition-property: color,background;` `transition-timing-function: var(--ifm-transition-timing-default);`

## Anything Else
There was one callout for adding a `Back to Radar.io` link to the narrow view header menu and fixing the obfuscated Scroll To Top Button in narrow viewports. We talked adhoc and decided to consolidate the header and sidebar navs in a narrow viewport. Since this is a larger body of work, it'll be done in a separate ticket/PR.