### PR TITLE
add breadcrumbs metadata and description meta tag

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-id: documentation
+id: overview
 title: Documentation
 slug: /
 ---

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,6 +11,7 @@ module.exports = {
   projectName: 'docs', // Usually your repo name.
   themeConfig: {
     metadatas: [
+      { name: "description", content: "Location data infrastructure | Geofencing SDK and API"},
       { name: "fb:app_id", content: "1026503440803301" },
       { name: "og:site_name", content: "Radar" },
       { name: "og:type", content: "website" },

--- a/sidebars.js
+++ b/sidebars.js
@@ -11,7 +11,7 @@
 
 module.exports = {
   defaultSidebar: [
-    { type: "doc", id: "documentation", label: "Overview" },
+    { type: "doc", id: "overview", label: "Overview" },
     "geofences",
     {
       type: "category",
@@ -91,7 +91,7 @@ module.exports = {
     "faqs",
   ],
   miscSidebar: [
-    { type: "doc", id: "documentation", label: "Overview" },
+    { type: "doc", id: "overview", label: "Overview" },
     "geofences",
     {
       type: "category",

--- a/src/components/radarSeo.jsx
+++ b/src/components/radarSeo.jsx
@@ -3,11 +3,76 @@ import Head from '@docusaurus/Head';
 import {useThemeConfig, useTitleFormatter} from '@docusaurus/theme-common';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+const ROOT_BREADCRUMB = {
+  name: 'Radar',
+  path: '/',
+};
+
+// String Utils
+export const capitalizeFirst = (string = '') => (
+  (string[0] || '').toUpperCase() + string.slice(1)
+);
+
+export const titleize = (string) => (
+  (string || '').split(/[\s+]/).map(capitalizeFirst).join(' ')
+);
+
+// Breadcrumbs Metadata
+const breadcrumbMetadata = (pageList) => {
+  const itemListElement = pageList.map((page, index) => {
+    const name = titleize(page.name || '');
+
+    return {
+      '@type': 'ListItem',
+      position: index + 1,
+      name,
+      item: {
+        '@id': `https://radar.io${page.path}`,
+        name,
+      },
+    };
+  });
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement,
+  };
+};
+
+export const getDocumentationBreadcrumbs = (slug, title) => {
+  const breadcrumbs = [
+    ROOT_BREADCRUMB,
+    { name: 'Documentation', path: '/documentation' },
+  ];
+
+  if (slug && title) {
+    if (slug === 'places/categories' || slug === 'places/chains') {
+      breadcrumbs.push(
+        { name: 'Places', path: '/documentation/places' },
+      );
+    }
+    breadcrumbs.push(
+      { name: title, path: `/documentation/${slug}` },
+    );
+  }
+
+  return breadcrumbMetadata(breadcrumbs);
+};
+
+export const structuredData = (data) => (
+  <script
+    type="application/ld+json"
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+  />
+);
+
 const RadarSEO = ({
   title,
   _description,
   keywords,
   image,
+  slug
 }) => {
   const {image: defaultImage} = useThemeConfig();
   const pageImage = useBaseUrl(image || defaultImage, {absolute: true});
@@ -42,6 +107,7 @@ const RadarSEO = ({
       {pageImage && <meta property="og:image" content={pageImage} />}
       {pageImage && <meta name="twitter:image" content={pageImage} />}
       {pageImage && <meta name="twitter:card" content="summary_large_image" />}
+      {structuredData(getDocumentationBreadcrumbs(slug, title))}
     </Head>
   )
 }

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -35,6 +35,7 @@ function DocItem(props) {
     lastUpdatedAt,
     formattedLastUpdatedAt,
     lastUpdatedBy,
+    slug,
   } = metadata;
   const {pluginId} = useActivePlugin({
     failfast: true,
@@ -48,10 +49,12 @@ function DocItem(props) {
   // See https://github.com/facebook/docusaurus/issues/4665#issuecomment-825831367
 
   const metaTitle = frontMatter.title || title;
+
   return (
     <>
       <RadarSEO
         {...{
+          slug,
           title: metaTitle,
           description,
           keywords,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
A.) Changes docs landing page id from `documentation` to `overview`
B.) Adds `structured data` breadcrumb tags to Docs pages

## Why?
A.) Canonical URL is auto-populated by Docusaurus. Even though the doc landing page has the slug `/documentation`, it's `og:url` and canonical url are being generated based on the `id` frontmatter attached to the page. By changing the `id`, it should create 
B.) These were missing in the initial metadata sweep. These should be available now.

## How?
A.) `id` frontmatter was updated
B.) Added helper methods from `frontend` and updated `DocItem` to pass `slug` metadata to the `RadarSEO` component