### PR TITLE
Use PNG Favicon instead of ICO

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,7 +6,7 @@ module.exports = {
   baseUrl: '/documentation/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
-  favicon: 'img/favicon.ico',
+  favicon: 'img/favicon.png',
   organizationName: 'radarlabs', // Usually your GitHub org/user name.
   projectName: 'docs', // Usually your repo name.
   themeConfig: {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
Use `.png` favicon instead of `.ico`

## Why?
The favicon is blurry!

Also, while `.ico` favicons are the preferred legacy version, there is wide support for PNG favicons now.

## How?
Updated `docusaurus.config.js`

## Screenshots (optional)
ICO Favicon:
![image](https://user-images.githubusercontent.com/1566055/121918512-19b83d00-cd04-11eb-8227-a6e3144b2611.png)

PNG Favicon:
![image](https://user-images.githubusercontent.com/1566055/121918471-0efda800-cd04-11eb-97d7-c24a84d1624e.png)

## Anything Else? (optional)
Should probably add Apple Touch Icons and what not just in case...
