### PR TITLE
Add sidebar for tracking reference page

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -127,6 +127,7 @@ module.exports = {
         "sdk/cordova",
         "sdk/capacitor",
         "sdk/flutter",
+        "sdk/tracking"
       ],
     },
     "api",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
SDK Tracking Reference page is missing a sidebar

## Why?
We want consistency across our doc pages, including rogue pages.

## How?
Add a link to tracking reference page in the expanded sidebar (sidebar with rogue pages) in `sidebar.js`
