### PR TITLE
Responsive Sidebar > Responsive Header Nav in Narrow Viewports

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -234,6 +234,21 @@ strong {
   height: auto;
 }
 
+/* Sidebar overrides */
+
+.menu__list-item {
+  margin: 0;
+}
+
+.menu__link {
+  border-radius: 0;
+}
+
+.menu__link--active,
+.menu__link--active:hover {
+  font-weight: var(--ifm-font-weight-semibold);
+  background: var(--ifm-menu-color-background);
+}
 
 /* Table of Contents overrides */
 
@@ -423,4 +438,33 @@ table th, table td {
 
 .tabs__item:hover {
   background: var(--radar-gray-1);
+}
+
+.sidebar-brand {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  height: var(--ifm-navbar-height);
+  padding: var(--ifm-navbar-padding-vertical) var(--ifm-navbar-padding-horizontal);
+  border-bottom: 1px solid var(--radar-gray-2);
+  margin-bottom: 15px;
+}
+
+.menu--show {
+  padding: 0;
+}
+
+.menu--responsive .menu__button {
+  top: 17px;
+  bottom: auto;
+  left: 19px;
+  right: auto;
+  background: white;
+  border: none;
+  padding: 2px;
+}
+
+.menu--responsive.menu--show .menu__button {
+  left: auto;
+  right: 20px;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -234,27 +234,6 @@ strong {
   height: auto;
 }
 
-/* Sidebar overrides */
-
-.menu {
-  padding: 0 !important;
-  padding-top: 15px;
-  font-weight: var(--ifm-font-weight-normal);
-}
-
-.menu__list-item {
-  margin: 0;
-}
-
-.menu__link {
-  border-radius: 0;
-}
-
-.menu__link--active,
-.menu__link--active:hover {
-  font-weight: var(--ifm-font-weight-semibold);
-  background: var(--ifm-menu-color-background);
-}
 
 /* Table of Contents overrides */
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -455,7 +455,7 @@ table th, table td {
 }
 
 .menu--responsive .menu__button {
-  top: 17px;
+  top: 16px;
   bottom: auto;
   left: 19px;
   right: auto;

--- a/src/theme/DocSidebar/index.js
+++ b/src/theme/DocSidebar/index.js
@@ -1,0 +1,347 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, {useState, useCallback, useEffect, useRef, memo} from 'react';
+import clsx from 'clsx';
+import {useThemeConfig, isSamePath} from '@docusaurus/theme-common';
+import useUserPreferencesContext from '@theme/hooks/useUserPreferencesContext';
+import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
+import useWindowSize, {windowSizes} from '@theme/hooks/useWindowSize';
+import useScrollPosition from '@theme/hooks/useScrollPosition';
+import Link from '@docusaurus/Link';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import Logo from '@theme/Logo';
+import IconArrow from '@theme/IconArrow';
+import IconMenu from '@theme/IconMenu';
+import {translate} from '@docusaurus/Translate';
+import styles from './styles.module.css';
+const MOBILE_TOGGLE_SIZE = 24;
+
+function usePrevious(value) {
+  const ref = useRef(value);
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}
+
+const isActiveSidebarItem = (item, activePath) => {
+  if (item.type === 'link') {
+    return isSamePath(item.href, activePath);
+  }
+
+  if (item.type === 'category') {
+    return item.items.some((subItem) =>
+      isActiveSidebarItem(subItem, activePath),
+    );
+  }
+
+  return false;
+}; // Optimize sidebar at each "level"
+// TODO this item should probably not receive the "activePath" props
+// TODO this triggers whole sidebar re-renders on navigation
+
+const DocSidebarItems = memo(function DocSidebarItems({items, ...props}) {
+  return items.map((item, index) => (
+    <DocSidebarItem
+      key={index} // sidebar is static, the index does not change
+      item={item}
+      {...props}
+    />
+  ));
+});
+
+function DocSidebarItem(props) {
+  switch (props.item.type) {
+    case 'category':
+      return <DocSidebarItemCategory {...props} />;
+
+    case 'link':
+    default:
+      return <DocSidebarItemLink {...props} />;
+  }
+}
+
+function DocSidebarItemCategory({
+  item,
+  onItemClick,
+  collapsible,
+  activePath,
+  ...props
+}) {
+  const {items, label} = item;
+  const isActive = isActiveSidebarItem(item, activePath);
+  const wasActive = usePrevious(isActive); // active categories are always initialized as expanded
+  // the default (item.collapsed) is only used for non-active categories
+
+  const [collapsed, setCollapsed] = useState(() => {
+    if (!collapsible) {
+      return false;
+    }
+
+    return isActive ? false : item.collapsed;
+  });
+  const menuListRef = useRef(null);
+  const [menuListHeight, setMenuListHeight] = useState(undefined);
+
+  const handleMenuListHeight = (calc = true) => {
+    setMenuListHeight(
+      calc ? `${menuListRef.current?.scrollHeight}px` : undefined,
+    );
+  }; // If we navigate to a category, it should automatically expand itself
+
+  useEffect(() => {
+    const justBecameActive = isActive && !wasActive;
+
+    if (justBecameActive && collapsed) {
+      setCollapsed(false);
+    }
+  }, [isActive, wasActive, collapsed]);
+  const handleItemClick = useCallback(
+    (e) => {
+      e.preventDefault();
+
+      if (!menuListHeight) {
+        handleMenuListHeight();
+      }
+
+      setTimeout(() => setCollapsed((state) => !state), 100);
+    },
+    [menuListHeight],
+  );
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <li
+      className={clsx('menu__list-item', {
+        'menu__list-item--collapsed': collapsed,
+      })}>
+      <a
+        className={clsx('menu__link', {
+          'menu__link--sublist': collapsible,
+          'menu__link--active': collapsible && isActive,
+          [styles.menuLinkText]: !collapsible,
+        })}
+        onClick={collapsible ? handleItemClick : undefined}
+        href={collapsible ? '#!' : undefined}
+        {...props}>
+        {label}
+      </a>
+      <ul
+        className="menu__list"
+        ref={menuListRef}
+        style={{
+          height: menuListHeight,
+        }}
+        onTransitionEnd={() => {
+          if (!collapsed) {
+            handleMenuListHeight(false);
+          }
+        }}>
+        <DocSidebarItems
+          items={items}
+          tabIndex={collapsed ? '-1' : '0'}
+          onItemClick={onItemClick}
+          collapsible={collapsible}
+          activePath={activePath}
+        />
+      </ul>
+    </li>
+  );
+}
+
+function DocSidebarItemLink({
+  item,
+  onItemClick,
+  activePath,
+  collapsible: _collapsible,
+  ...props
+}) {
+  const {href, label} = item;
+  const isActive = isActiveSidebarItem(item, activePath);
+  return (
+    <li className="menu__list-item" key={label}>
+      <Link
+        className={clsx('menu__link', {
+          'menu__link--active': isActive,
+          [styles.menuLinkExternal]: !isInternalUrl(href),
+        })}
+        to={href}
+        {...(isInternalUrl(href) && {
+          isNavLink: true,
+          exact: true,
+          onClick: onItemClick,
+        })}
+        {...props}>
+        {label}
+      </Link>
+    </li>
+  );
+}
+
+function useShowAnnouncementBar() {
+  const {isAnnouncementBarClosed} = useUserPreferencesContext();
+  const [showAnnouncementBar, setShowAnnouncementBar] = useState(
+    !isAnnouncementBarClosed,
+  );
+  useScrollPosition(({scrollY}) => {
+    if (!isAnnouncementBarClosed) {
+      setShowAnnouncementBar(scrollY === 0);
+    }
+  });
+  return showAnnouncementBar;
+}
+
+function useResponsiveSidebar() {
+  const [showResponsiveSidebar, setShowResponsiveSidebar] = useState(false);
+  useLockBodyScroll(showResponsiveSidebar);
+  const windowSize = useWindowSize();
+  useEffect(() => {
+    if (windowSize === windowSizes.desktop) {
+      setShowResponsiveSidebar(false);
+    }
+  }, [windowSize]);
+  const closeResponsiveSidebar = useCallback(
+    (e) => {
+      e.target.blur();
+      setShowResponsiveSidebar(false);
+    },
+    [setShowResponsiveSidebar],
+  );
+  const toggleResponsiveSidebar = useCallback(() => {
+    setShowResponsiveSidebar((value) => !value);
+  }, [setShowResponsiveSidebar]);
+  return {
+    showResponsiveSidebar,
+    closeResponsiveSidebar,
+    toggleResponsiveSidebar,
+  };
+}
+
+function HideableSidebarButton({onClick}) {
+  return (
+    <button
+      type="button"
+      title={translate({
+        id: 'theme.docs.sidebar.collapseButtonTitle',
+        message: 'Collapse sidebar',
+        description: 'The title attribute for collapse button of doc sidebar',
+      })}
+      aria-label={translate({
+        id: 'theme.docs.sidebar.collapseButtonAriaLabel',
+        message: 'Collapse sidebar',
+        description: 'The title attribute for collapse button of doc sidebar',
+      })}
+      className={clsx(
+        'button button--secondary button--outline',
+        styles.collapseSidebarButton,
+      )}
+      onClick={onClick}>
+      <IconArrow className={styles.collapseSidebarButtonIcon} />
+    </button>
+  );
+}
+
+function ResponsiveSidebarButton({responsiveSidebarOpened, onClick}) {
+  return (
+    <button
+      aria-label={
+        responsiveSidebarOpened
+          ? translate({
+              id: 'theme.docs.sidebar.responsiveCloseButtonLabel',
+              message: 'Close menu',
+              description:
+                'The ARIA label for close button of mobile doc sidebar',
+            })
+          : translate({
+              id: 'theme.docs.sidebar.responsiveOpenButtonLabel',
+              message: 'Open menu',
+              description:
+                'The ARIA label for open button of mobile doc sidebar',
+            })
+      }
+      aria-haspopup="true"
+      className="button button--secondary button--sm menu__button"
+      type="button"
+      onClick={onClick}>
+      {responsiveSidebarOpened ? (
+        <span
+          className={clsx(styles.sidebarMenuIcon, styles.sidebarMenuCloseIcon)}>
+          &times;
+        </span>
+      ) : (
+        <IconMenu
+          className={styles.sidebarMenuIcon}
+          height={MOBILE_TOGGLE_SIZE}
+          width={MOBILE_TOGGLE_SIZE}
+        />
+      )}
+    </button>
+  );
+}
+
+function DocSidebar({
+  path,
+  sidebar,
+  sidebarCollapsible = true,
+  onCollapse,
+  isHidden,
+}) {
+  const showAnnouncementBar = useShowAnnouncementBar();
+  const {
+    navbar: {hideOnScroll},
+    hideableSidebar,
+  } = useThemeConfig();
+  const {isAnnouncementBarClosed} = useUserPreferencesContext();
+  const {
+    showResponsiveSidebar,
+    closeResponsiveSidebar,
+    toggleResponsiveSidebar,
+  } = useResponsiveSidebar();
+  return (
+    <div
+      className={clsx(styles.sidebar, {
+        [styles.sidebarWithHideableNavbar]: hideOnScroll,
+        [styles.sidebarHidden]: isHidden,
+      })}>
+      {hideOnScroll && <Logo tabIndex={-1} className={styles.sidebarLogo} />}
+      <div
+        className={clsx(
+          'menu',
+          'menu--responsive',
+          'thin-scrollbar',
+          styles.menu,
+          {
+            'menu--show': showResponsiveSidebar,
+            [styles.menuWithAnnouncementBar]:
+              !isAnnouncementBarClosed && showAnnouncementBar,
+          },
+        )}>
+        <ResponsiveSidebarButton
+          responsiveSidebarOpened={showResponsiveSidebar}
+          onClick={toggleResponsiveSidebar}
+        />
+        <ul className="menu__list">
+          <DocSidebarItems
+            items={sidebar}
+            onItemClick={closeResponsiveSidebar}
+            collapsible={sidebarCollapsible}
+            activePath={path}
+          />
+          <li className={styles.menuFooter}>
+            <a className={styles.menuHomeButton} href="https://radar.io">Back to Radar.io</a>
+          </li>
+        </ul>
+      </div>
+      {hideableSidebar && <HideableSidebarButton onClick={onCollapse} />}
+    </div>
+  );
+}
+
+export default DocSidebar;

--- a/src/theme/DocSidebar/index.js
+++ b/src/theme/DocSidebar/index.js
@@ -346,7 +346,20 @@ function DocSidebar({
             activePath={path}
           />
           <li className={styles.menuFooter}>
-            <a className={styles.menuHomeButton} href="https://radar.io">Back to Radar.io</a>
+            <a
+              className={styles.menuHomeButton}
+              href="https://radar.io"
+            >
+              Back to Radar.io
+            </a>
+            {showResponsiveSidebar &&
+              <a
+                className={styles.menuHomeButton}
+                href="https://radar.io/login"
+              >
+                Dashboard
+              </a>
+            }
           </li>
         </ul>
       </div>

--- a/src/theme/DocSidebar/index.js
+++ b/src/theme/DocSidebar/index.js
@@ -327,6 +327,17 @@ function DocSidebar({
           responsiveSidebarOpened={showResponsiveSidebar}
           onClick={toggleResponsiveSidebar}
         />
+        {
+          showResponsiveSidebar &&
+          <div className="sidebar-brand">
+            <Logo
+              className="navbar__brand"
+              imageClassName="navbar__logo"
+              titleClassName="navbar__title"
+              onClick={toggleResponsiveSidebar}
+            />
+          </div>
+        }
         <ul className="menu__list">
           <DocSidebarItems
             items={sidebar}

--- a/src/theme/DocSidebar/styles.module.css
+++ b/src/theme/DocSidebar/styles.module.css
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+:root {
+  --collapse-button-bg-color-dark: #2e333a;
+}
+
+@media (min-width: 997px) {
+  .sidebar {
+    display: flex;
+    flex-direction: column;
+    max-height: 100vh;
+    height: 100%;
+    position: sticky;
+    top: 0;
+    padding-top: var(--ifm-navbar-height);
+    width: var(--doc-sidebar-width);
+    transition: opacity 50ms ease;
+  }
+
+  .sidebarWithHideableNavbar {
+    padding-top: 0;
+  }
+
+  .sidebarHidden {
+    opacity: 0;
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
+  }
+
+  .sidebarLogo {
+    display: flex !important;
+    align-items: center;
+    margin: 0 var(--ifm-navbar-padding-horizontal);
+    min-height: var(--ifm-navbar-height);
+    max-height: var(--ifm-navbar-height);
+    color: inherit !important;
+    text-decoration: none !important;
+  }
+
+  .sidebarLogo img {
+    margin-right: 0.5rem;
+    height: 2rem;
+  }
+
+  .menu {
+    flex-grow: 1;
+    padding: 15px 0 0;
+    font-weight: var(--ifm-font-weight-normal);
+  }
+
+  .menuLinkText {
+    cursor: initial;
+  }
+
+  .menuLinkText:hover {
+    background: none;
+  }
+
+  .menuWithAnnouncementBar {
+    margin-bottom: var(--docusaurus-announcement-bar-height);
+  }
+
+  .collapseSidebarButton {
+    display: block !important;
+    background-color: var(--ifm-button-background-color);
+    height: 40px;
+    position: sticky;
+    bottom: 0;
+    border-radius: 0;
+    border: 1px solid var(--ifm-toc-border-color);
+  }
+
+  .collapseSidebarButtonIcon {
+    transform: rotate(180deg);
+    margin-top: 4px;
+  }
+  html[dir='rtl'] .collapseSidebarButtonIcon {
+    transform: rotate(0);
+  }
+
+  html[data-theme='dark'] .collapseSidebarButton {
+    background-color: var(--collapse-button-bg-color-dark);
+  }
+
+  html[data-theme='dark'] .collapseSidebarButton:hover,
+  html[data-theme='dark'] .collapseSidebarButton:focus {
+    background-color: var(--ifm-color-emphasis-200);
+  }
+}
+
+.sidebarLogo,
+.collapseSidebarButton {
+  display: none;
+}
+
+.sidebarMenuIcon {
+  vertical-align: middle;
+}
+
+.sidebarMenuCloseIcon {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  height: 24px;
+  font-size: 1.5rem;
+  font-weight: var(--ifm-font-weight-bold);
+  line-height: 0.9;
+  width: 24px;
+}
+
+:global(.menu__list) :global(.menu__list) {
+  overflow-y: hidden;
+  will-change: height;
+  transition: height var(--ifm-transition-fast) linear;
+}
+
+:global(.menu__list-item--collapsed) :global(.menu__list) {
+  height: 0 !important;
+}
+
+.menuLinkExternal {
+  align-items: center;
+}
+.menuLinkExternal:after {
+  content: '';
+  height: 1.15rem;
+  width: 1.15rem;
+  min-width: 1.15rem;
+  margin: 0 0 0 3%;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24'%3E%3Cpath fill='rgba(0,0,0,0.5)' d='M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z'/%3E%3C/svg%3E")
+    no-repeat;
+  filter: var(--ifm-menu-link-sublist-icon-filter);
+}
+
+/* Overrides */
+.menu {
+  padding: 15px 0 0;
+  font-weight: var(--ifm-font-weight-normal);
+}
+
+.menu__list-item {
+  margin: 0;
+}
+
+.menu__link {
+  border-radius: 0;
+}
+
+.menu__link--active,
+.menu__link--active:hover {
+  font-weight: var(--ifm-font-weight-semibold);
+  background: var(--ifm-menu-color-background);
+}
+
+.menuFooter {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  border-top: 1px solid var(--ifm-color-gray-200);
+  padding: 16px;
+}
+
+.menuHomeButton{
+  color: var(--ifm-menu-color-active);
+  font-weight: var(--ifm-font-weight-semibold);
+}

--- a/src/theme/DocSidebar/styles.module.css
+++ b/src/theme/DocSidebar/styles.module.css
@@ -148,6 +148,10 @@
   border-top: 1px solid var(--ifm-color-gray-200);
   border-right: 1px solid var(--ifm-color-gray-200);
   background: white;
+
+  /* For responsive sidebar */
+  display: flex;
+  justify-content: space-between;
 }
 
 .menuHomeButton {

--- a/src/theme/DocSidebar/styles.module.css
+++ b/src/theme/DocSidebar/styles.module.css
@@ -138,35 +138,23 @@
   filter: var(--ifm-menu-link-sublist-icon-filter);
 }
 
-/* Overrides */
-.menu {
-  padding: 15px 0 0;
-  font-weight: var(--ifm-font-weight-normal);
-}
-
-.menu__list-item {
-  margin: 0;
-}
-
-.menu__link {
-  border-radius: 0;
-}
-
-.menu__link--active,
-.menu__link--active:hover {
-  font-weight: var(--ifm-font-weight-semibold);
-  background: var(--ifm-menu-color-background);
-}
+/* Custom elements */
 
 .menuFooter {
   position: absolute;
   bottom: 0;
   width: 100%;
-  border-top: 1px solid var(--ifm-color-gray-200);
   padding: 16px;
+  border-top: 1px solid var(--ifm-color-gray-200);
+  border-right: 1px solid var(--ifm-color-gray-200);
+  background: white;
 }
 
-.menuHomeButton{
+.menuHomeButton {
   color: var(--ifm-menu-color-active);
   font-weight: var(--ifm-font-weight-semibold);
+}
+
+.menuHomeButton:hover {
+  text-decoration: none;
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
Fixed a few usability issues with the narrow view of the Docs:
- Added a `Back to Radar.io` button to the sidebar - this is always visible
- Added a Dashboard link to the sidebar - this is visible only in narrow views
- Moved responsive sidebar button to top-left (in a hacky way... more in the `How` section)

## Why?
There are some usability issues with the current Navbar + Sidebar in narrower viewports:
- Page has 2 hamburger menus (but no clear indication which menu opens what)
- Default responsive sidebar button obfuscates scroll to top button

This change makes the sidebar menu the main navigation for the page (since its more contextually relevant to the content anyway).

## How?
This is definitely a hackier implementation since the responsive sidebar menu just obfuscates the original menu with CSS. I went with this route mostly for the speed of implementation, but this is definitely a code smell.

A better implementation would be:
1.) Adding a context for Sidebar, e.g. `SidebarContext`
2.) Updating `SidebarContext` via the `DocSidebar` swizzled component
3.) Updating the Navbar component to ingest data from the `SidebarContext` and replacing the button entirely

But this'll take considerable effort and may not play well with future updates since the `Navbar` is not a [swizzle-friendly component yet](https://docusaurus.io/docs/lifecycle-apis#getswizzlecomponentlist) and this requires rewriting rather than just adding elements

## Screenshots (optional)
Wide view
![image](https://user-images.githubusercontent.com/1566055/122112099-77c14f00-cdee-11eb-974e-c7d4f2bd8df1.png)

Narrow view
![image](https://user-images.githubusercontent.com/1566055/122112155-84de3e00-cdee-11eb-84ae-29a837744c03.png)

Narrow view w/ sidebar modal
![image](https://user-images.githubusercontent.com/1566055/122112207-90316980-cdee-11eb-9bf6-74a09bd81fa1.png)

