### PR TITLE
Fix sidebar scrolling on narrow view

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -420,6 +420,12 @@ table th, table td {
   margin-bottom: 15px;
 }
 
+.sidebar-menu.menu__list {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100% - 75px);
+}
+
 .menu--show {
   padding: 0;
 }

--- a/src/theme/DocSidebar/index.js
+++ b/src/theme/DocSidebar/index.js
@@ -341,7 +341,7 @@ function DocSidebar({
             />
           </div>
         }
-        <ul className="menu__list">
+        <ul className="menu__list sidebar-menu">
           <DocSidebarItems
             items={sidebar}
             onItemClick={closeResponsiveSidebar}

--- a/src/theme/DocSidebar/styles.module.css
+++ b/src/theme/DocSidebar/styles.module.css
@@ -54,7 +54,7 @@
 
   .menu {
     flex-grow: 1;
-    padding: 15px 0 0;
+    padding: 15px 0 60px;
   }
 
   .menuLinkText {
@@ -144,7 +144,6 @@
 /* Custom elements */
 
 .menuFooter {
-  position: absolute;
   bottom: 0;
   width: 100%;
   padding: 16px;
@@ -155,6 +154,14 @@
   /* For responsive sidebar */
   display: flex;
   justify-content: space-between;
+  justify-self: flex-end;
+  margin-top: auto;
+}
+
+@media (min-width: 997px) {
+  .menuFooter {
+    position: absolute;
+  }
 }
 
 .menuHomeButton {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
There were some scrolling issues with the sidebar modal in narrow viewports.

https://files.slack.com/files-pri/T1D3DQ9QA-F025NK4LAN5/scroll.gif

## Why?
This was caused by a CSS rule that did not take a growing sidebar into account. This is now updated to prevent such issues from happening.

## How?
- Added `display:flex` to the menu governing the sidebar and set an a `min-height` and `margin-top: auto` to the sidebar footer so that the links at the bottom stay at the bottom.
