### PR TITLE
adjust font sizes on mobile, and some other small adjustments

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -104,8 +104,8 @@ h6 {
 
 /* Responsive font adjustments */
 @media (max-width: 996px) {
-  h1, h1.docTitle_src-theme-DocItem- {
-    font-size: 2.5rem;
+  h1 {
+    font-size: 2.25rem;
   }
   h2 {
     font-size: 2rem;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -247,12 +247,18 @@ strong {
 }
 
 @media (max-width: 996px) {
+  /* Offset header height*/
+  body {
+    padding-top: 60px;
+  }
+  /* Use a fixed (instead of sticky) header */
+  .navbar--fixed-top {
+    position: fixed;
+  }
+
+  /* Hide the drawer icon thats being overlaid */
   .navbar__toggle {
     visibility: hidden;
-  }
-  .sidebarMenuIcon_src-theme-DocSidebar-.sidebarMenuCloseIcon_src-theme-DocSidebar- {
-    font-weight: normal;
-    margin-top: -2px;
   }
 }
 
@@ -457,7 +463,7 @@ table th, table td {
 }
 
 .menu--responsive .menu__button {
-  position: absolute;
+  position: fixed;
   top: 16px;
   bottom: auto;
   left: 19px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -102,6 +102,22 @@ h6 {
   letter-spacing: 1px;
 }
 
+/* Responsive font adjustments */
+@media (max-width: 996px) {
+  h1, h1.docTitle_src-theme-DocItem- {
+    font-size: 2.5rem;
+  }
+  h2 {
+    font-size: 2rem;
+  }
+  h3 {
+    font-size: 1.25rem;
+  }
+  h4 {
+    font-size: 1rem;
+  }
+}
+
 code {
   border: none;
   font-variant-ligatures: none;
@@ -227,6 +243,16 @@ strong {
 @media (min-width: 996px) {
   .navbar__brand {
     border-right: 1px solid var(--ifm-toc-border-color);
+  }
+}
+
+@media (max-width: 996px) {
+  .navbar__toggle {
+    visibility: hidden;
+  }
+  .sidebarMenuIcon_src-theme-DocSidebar-.sidebarMenuCloseIcon_src-theme-DocSidebar- {
+    font-weight: normal;
+    margin-top: -2px;
   }
 }
 
@@ -431,6 +457,7 @@ table th, table td {
 }
 
 .menu--responsive .menu__button {
+  position: absolute;
   top: 16px;
   bottom: auto;
   left: 19px;

--- a/src/theme/DocItem/styles.module.css
+++ b/src/theme/DocItem/styles.module.css
@@ -10,6 +10,12 @@
   margin-bottom: calc(var(--ifm-leading-desktop) * var(--ifm-leading));
 }
 
+@media (max-width: 996px) {
+  h1.docTitle {
+    font-size: 2.25rem;
+  }
+}
+
 .docItemContainer {
   margin: 0 auto;
   padding: 0 0.5rem;

--- a/src/theme/DocSidebar/styles.module.css
+++ b/src/theme/DocSidebar/styles.module.css
@@ -116,6 +116,12 @@
   line-height: 0.9;
   width: 24px;
 }
+@media (max-width: 996px) {
+  .sidebarMenuCloseIcon {
+    font-weight: normal;
+    margin-top: -2px;
+  }
+}
 
 :global(.menu__list) :global(.menu__list) {
   overflow-y: hidden;


### PR DESCRIPTION
## What?
Mobile adjustments:
* Reduce font sizes on mobile viewports
* Set close-icon weight to `normal`
* Set desktop navbar to `hidden` when mobile button is overlaid to prevent it from leaking through

## Screenshots (optional)

### Font Fixes
![image](https://user-images.githubusercontent.com/814934/122570907-33b29200-d01a-11eb-83cf-3f4499d15b3b.png)

### Navbar Fixes
![image](https://user-images.githubusercontent.com/814934/122573234-9016b100-d01c-11eb-8cf7-4ad273bb3098.png)
