### PR TITLE
Docs updates: getMatrix(), ipGeocode(), platform and use case copy

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -4,7 +4,7 @@ title: API Reference
 id: api
 ---
 
-Use Radar APIs as [building blocks for location-based products and services](#building-blocks) like curbside pickup and delivery tracking, store locators, address autocomplete, location-based content and notifications, and more. Or, use Radar APIs to [manage your Radar data](#manage-your-radar-data), including users, geofences, and events.
+Use Radar APIs as [building blocks for location-based products and services](#building-blocks) like pickup and delivery tracking, location-triggered notifications, location verification, store locators, address autocomplete, and more. Or, use Radar APIs to [manage your Radar data](#manage-your-radar-data), including users, geofences, and events.
 
 The API is RESTful, with predictable, resource-oriented URLs. All responses, including errors, return JSON. <span className="badge badge--info">POST</span> and <span className="badge badge--warning">PUT</span> request body parameters may be sent as `application/json` or `application/x-www-form-urlencoded`.
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -9,7 +9,7 @@ import LinkCard from '../src/components/LinkCard'
 import IconCard from '../src/components/IconCard'
 import Card from '../src/components/TileCard';
 
-Radar is location data infrastructure. You can use our [SDKs](/sdk) and [APIs](/api) to build a wide range of location-based product and service experiences, including curbside pickup and delivery tracking, store locators, address autocomplete, location-based content and notifications, and more.
+Radar is the leading geofencing and location tracking platform. You can use our [SDKs](/sdk) and [APIs](/api) to build a wide range of location-based product and service experiences, including pickup and delivery tracking, location-triggered notifications, location verification, store locators, address autocomplete, and more.
 
 ## Quickstart
 

--- a/docs/sdk/android.mdx
+++ b/docs/sdk/android.mdx
@@ -977,8 +977,8 @@ With the [IP geocoding API](/api#ip-geocode), geocode the device's current IP ad
   ```java
   Radar.ipGeocode(new RadarIpGeocodeCallback() {
       @Override
-      public void onComplete(RadarStatus status, RadarAddress address) {
-          // do something with address
+      public void onComplete(RadarStatus status, RadarAddress address, boolean proxy) {
+          // do something with address, proxy
       }
   });
   ```
@@ -987,8 +987,8 @@ With the [IP geocoding API](/api#ip-geocode), geocode the device's current IP ad
   <TabItem value="kotlin">
 
   ```kotlin
-  Radar.ipGeocode { status, address ->
-      // do something with address
+  Radar.ipGeocode { status, address, proxy ->
+      // do something with address, proxy
   }
   ```
 

--- a/docs/sdk/cordova.mdx
+++ b/docs/sdk/cordova.mdx
@@ -364,6 +364,37 @@ cordova.plugins.radar.getDistance({
 });
 ```
 
+#### Matrix
+
+With the [matrix API](/api#matrix), calculate the travel distance and duration between multiple origins and destinations for up to 25 routes:
+
+```javascript
+cordova.plugins.radar.getMatrix({
+  origins: [
+    {
+			latitude: 40.78382,
+			longitude: -73.97536
+		}
+  ],
+  destinations: [
+    [
+      {
+        latitude: 40.70390,
+        longitude: -73.98670
+      },
+      {
+        latitude: 40.73237,
+        longitude: -73.94884
+      }
+    ]
+  ],
+  mode: 'car',
+  units: 'imperial'
+}, (result) => {
+  // do something with result.status, result.matrix
+});
+```
+
 ## Support
 
 Have questions? We're here to help! Email us at [support@radar.io](mailto:support@radar.io).

--- a/docs/sdk/cordova.mdx
+++ b/docs/sdk/cordova.mdx
@@ -372,9 +372,9 @@ With the [matrix API](/api#matrix), calculate the travel distance and duration b
 cordova.plugins.radar.getMatrix({
   origins: [
     {
-			latitude: 40.78382,
-			longitude: -73.97536
-		}
+      latitude: 40.78382,
+      longitude: -73.97536
+    }
   ],
   destinations: [
     [

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -144,7 +144,7 @@ Radar respects [standard iOS location permissions](https://developer.apple.com/d
       <strong><code>kCLAuthorizationStatusAuthorizedWhenInUse</code></strong>
     </InlineTabItem>
     <InlineTabItem groupId="ios" value="swift">
-      <strong><code>authorizedWhenInUse</code></strong>
+      <strong><code>.authorizedWhenInUse</code></strong>
     </InlineTabItem>
   </InlineTabs> or
   <InlineTabs>
@@ -152,7 +152,7 @@ Radar respects [standard iOS location permissions](https://developer.apple.com/d
       <strong><code>kCLAuthorizationStatusAuthorizedAlways</code></strong>
     </InlineTabItem>
     <InlineTabItem groupId="ios" value="swift">
-      <strong><code>authorizedAlways</code></strong>
+      <strong><code>.authorizedAlways</code></strong>
     </InlineTabItem>
   </InlineTabs>. For background tracking or geofencing with responsive mode, the app's location authorization status must be{" "}
   <InlineTabs>
@@ -160,7 +160,7 @@ Radar respects [standard iOS location permissions](https://developer.apple.com/d
       <strong><code>kCLAuthorizationStatusAuthorizedAlways</code></strong>
     </InlineTabItem>
     <InlineTabItem groupId="ios" value="swift">
-      <strong><code>authorizedAlways</code></strong>
+      <strong><code>.authorizedAlways</code></strong>
     </InlineTabItem>
   </InlineTabs>.
 </p>
@@ -363,7 +363,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>success</code>
+          <code>.success</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -378,7 +378,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorPublishableKey</code>
+          <code>.errorPublishableKey</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -393,7 +393,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorPermissions</code>
+          <code>.errorPermissions</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -408,7 +408,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorLocation</code>
+          <code>.errorLocation</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -423,7 +423,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorNetwork</code>
+          <code>.errorNetwork</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -438,7 +438,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorBadRequest</code>
+          <code>.errorBadRequest</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -453,7 +453,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorUnauthorized</code>
+          <code>.errorUnauthorized</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -468,7 +468,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorPaymentRequired</code>
+          <code>.errorPaymentRequired</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -483,7 +483,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorForbidden</code>
+          <code>.errorForbidden</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -498,7 +498,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorNotFound</code>
+          <code>.errorNotFound</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -513,7 +513,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorRateLimit</code>
+          <code>.errorRateLimit</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -528,7 +528,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorServer</code>
+          <code>.errorServer</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -543,7 +543,7 @@ You may provide an optional `completionHandler` that receives the request status
       </InlineTabItem>
       <InlineTabItem groupId="ios" value="swift">
         <strong>
-          <code>errorUnknown</code>
+          <code>.errorUnknown</code>
         </strong>
       </InlineTabItem>
     </InlineTabs>
@@ -1228,8 +1228,8 @@ With the [IP geocoding API](/api#ip-geocode), geocode the device's current IP ad
   <TabItem value="swift">
 
 ```swift
-Radar.ipGeocode { (status: RadarStatus, address: RadarAddress) in
-    // do something with address
+Radar.ipGeocode { (status: RadarStatus, address: RadarAddress, proxy: Bool) in
+    // do something with address, proxy
 }
 ```
 
@@ -1237,8 +1237,8 @@ Radar.ipGeocode { (status: RadarStatus, address: RadarAddress) in
   <TabItem value="objc">
 
 ```objc
-[Radar ipGeocodeWithCompletionHandler:^(RadarStatus status, RadarAddress *address) {
-    // do something with address
+[Radar ipGeocodeWithCompletionHandler:^(RadarStatus status, RadarAddress *address, BOOL proxy) {
+    // do something with address, proxy
 }];
 ```
 
@@ -1424,7 +1424,7 @@ With the [matrix API](/api#matrix), calculate the travel distance and duration b
   <TabItem value="swift">
 
 ```swift
-Radar.getDistance(
+Radar.getMatrix(
     origins: origins,
     destinations: destinations,
     mode: .car,


### PR DESCRIPTION
Trying my hand at a docs PR!

## What?
- Update platform positioning and use case copy on Overview and API pages
- Fix Swift getMatrix() code
- Add getMatrix() to Cordova SDK docs
- Add proxy to ipGeocode() callback
- Add dots before Swift enum values

## Why?
- Reflect the latest platform positioning used on our SDK repos and solution pages
- Address https://app.clubhouse.io/radarlabs/story/6503/also-looks-like-our-ip-geocoding-docs-are-outdated-not-included-in-the-callback