### PR TITLE
setting up CODEOWNERS for documentation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+-* @radarlabs/docs-approvers


### PR DESCRIPTION
## What?
Sets up a `CODEOWNERS` file so that PMs own approving documentation PRs

## Why?
So we can start to spread around the company who can approve documentation
