### PR TITLE
remove-ad-id-info

### DIFF
--- a/docs/integrations/branch.mdx
+++ b/docs/integrations/branch.mdx
@@ -16,12 +16,6 @@ Then, on the Radar [Integrations page](/integrations) under *Branch*, set *Enabl
 
 Whenever events are generated, Radar will send custom events to Branch.
 
-Radar sends `adId` (iOS IDFA, Android advertising ID) and `deviceId` (iOS IDFV, Android ID) to Branch. On SDK v3 and higher, you must manually enable `adId` collection. For example, on iOS:
-
-```swift
-Radar.setAdIdEnabled(true)
-```
-
 ## User mapping
 
 Radar `deviceId` maps to `idfv` for iOS devices and `android_id` for Android devices in Branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2302,27 +2302,6 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.22.tgz",
       "integrity": "sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA=="
     },
-    "@ndhoule/each": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ndhoule/each/-/each-2.0.1.tgz",
-      "integrity": "sha1-u+03KmA+BxOjGTxwanPd68W0Jqk=",
-      "requires": {
-        "@ndhoule/keys": "^2.0.0"
-      }
-    },
-    "@ndhoule/keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ndhoule/keys/-/keys-2.0.0.tgz",
-      "integrity": "sha1-PWSuZ3xlomF0e/OkV8YuspKk4M4="
-    },
-    "@ndhoule/map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ndhoule/map/-/map-2.0.1.tgz",
-      "integrity": "sha1-9coKR0JOpn9G4qbUmbnpvIhq76g=",
-      "requires": {
-        "@ndhoule/each": "^2.0.1"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",


### PR DESCRIPTION
## What?

Remove ad id info from branch documentation.

## Why?

Ad Id is not required for the branch integration (link on device ids) so omit from integration documentation
