### PR TITLE
Update Android continuous description to match SDK docs

### DIFF
--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -114,8 +114,8 @@ Radar.getPermissionsStatus().then((status) => {
 
 - **`GRANTED_BACKGROUND`**
 - **`GRANTED_FOREGROUND`**
+- **`NOT_DETERMINED`**
 - **`DENIED`**
-- **`UNKNOWN`**
 
 To request location permissions for the app, call:
 

--- a/docs/sdk/tracking.mdx
+++ b/docs/sdk/tracking.mdx
@@ -88,7 +88,7 @@ Option | Efficient | Responsive | Continuous
 
 ### Android presets
 
-- **`RadarTrackingOptions.CONTINUOUS`**: Updates about every 30 seconds while moving or stopped. Moderate battery usage. Starts a foreground service and shows a notification during tracking.
+- **`RadarTrackingOptions.CONTINUOUS`**: Updates about every 30 seconds while moving or stopped. Should be used with a foreground service. Moderate battery usage.
 - **`RadarTrackingOptions.RESPONSIVE`**: Updates about every 2.5 minutes while moving and shuts down when stopped to save battery. Once stopped, the device will need to move more than 100 meters to wake up and start moving again. Low battery usage, but may exceed Android vitals bad behavior thresholds for [excessive wakeups](https://developer.android.com/topic/performance/vitals/wakeup.html) and [excessive wi-fi scans](https://developer.android.com/topic/performance/vitals/bg-wifi.html).
 - **`RadarTrackingOptions.EFFICIENT`**: Updates as fast as every 6 minutes while moving and periodically when stopped. Once stopped, the device will need to move more than 100 meters and wait for at least 15 minutes to wake up and start moving again. Lowest battery usage and will not exceed Android vitals bad behavior thresholds.
 


### PR DESCRIPTION
To match https://github.com/radarlabs/radar-sdk-android/blob/master/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt#L329

We can set `trackingOptions.foregroundService = RadarTrackingOptionsForegroundService()` by default for `CONTINUOUS` in `3.2.x` and add detailed docs for `RadarTrackingOptionsForegroundService` in the future. In the meantime, `RadarTrackingOptionsForegroundService` is documented here https://radarlabs.github.io/radar-sdk-android/sdk/io.radar.sdk/-radar-tracking-options/-radar-tracking-options-foreground-service/index.html