### PR TITLE
Add note about Geofence Tag Blacklists to the integrations section

### DIFF
--- a/docs/integrations.mdx
+++ b/docs/integrations.mdx
@@ -92,6 +92,8 @@ To filter event types sent to an integration, select or unselect event types und
 
 To filter keys from the request body sent to an integration, add keys, comma-separated, to *Request Key Blacklist*. For example, to skip sending `radar_geofence_ids` to the Segment `identify` call and to skip sending `geofence_id` to the Segment `track` call, add `radar_geofence_ids,geofence_id` to *Request Key Blacklist*.
 
+To filter events sent to an integration based upon a [Geofence](/documentation/geofences) tag, add tags, comma-separated to *Geofence Tag Blacklist*. For example, to skip sending all events to the Amplitude integration for geofences tagged `gas-station` and `coffee-shop`, add `gas-station,coffee-shop` to *Geofence Tag Blacklist*.
+
 ## Geofence integrations
 
 *Geofence integrations* allow you to sync geofences from other systems to Radar.

--- a/docs/integrations.mdx
+++ b/docs/integrations.mdx
@@ -92,7 +92,7 @@ To filter event types sent to an integration, select or unselect event types und
 
 To filter keys from the request body sent to an integration, add keys, comma-separated, to *Request Key Blacklist*. For example, to skip sending `radar_geofence_ids` to the Segment `identify` call and to skip sending `geofence_id` to the Segment `track` call, add `radar_geofence_ids,geofence_id` to *Request Key Blacklist*.
 
-To filter events sent to an integration based upon a [Geofence](/documentation/geofences) tag, add tags, comma-separated to *Geofence Tag Blacklist*. For example, to skip sending all events to the Amplitude integration for geofences tagged `gas-station` and `coffee-shop`, add `gas-station,coffee-shop` to *Geofence Tag Blacklist*.
+To filter events sent to an integration based upon a [Geofence](/documentation/geofences) tag, add tags, comma-separated to *Geofence Tag Blacklist*. For example, to skip sending all events to the Amplitude integration for geofences tagged `gas-station` and `cafe`, add `gas-station,cafe` to *Geofence Tag Blacklist*.
 
 ## Geofence integrations
 


### PR DESCRIPTION
## What?
Adding a note about the `Geofence Tag Blacklist` advanced setting.
Open to feedback on wording.  The text reads as follows:
```
To filter events sent to an integration based upon a Geofence tag, add tags, comma-separated to Geofence Tag Blacklist. For example, to skip sending all events to the Amplitude integration for geofences tagged gas-station and coffee-shop, add gas-station,coffee-shop to Geofence Tag Blacklist.
```

## Why?
This is a new feature, so adding a small note will increase awareness to it and help users properly understand what is meant by the new setting for integrations.

## How?
Small note added to `/documentation/integrations#filters`.

## Screenshots (optional)

### Before
![image](https://user-images.githubusercontent.com/32653448/140994536-270267ca-764a-49bc-bcfd-217fe6d1e891.png)


### After

*Last paragraph in the **Filters** section*.

![image](https://user-images.githubusercontent.com/32653448/140994433-876eb0d7-4421-4986-8f89-c091703589b0.png)
