### PR TITLE
Add documentation for upserting a Beacon

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1573,6 +1573,7 @@ Gets a geofence. The geofence can be uniquely referenced by Radar `_id` or by `t
 ###### Definition
 
 <span className="badge badge--success">GET</span> <code>https://api.radar.io/v1/geofences/:id</code>
+<br />
 <span className="badge badge--success">GET</span> <code>https://api.radar.io/v1/geofences/:tag/:externalId</code>
 
 ###### Default rate limit
@@ -1679,6 +1680,7 @@ Deletes a geofence. The geofence can be uniquely referenced by Radar `_id` or by
 ###### Definition
 
 <span className="badge badge--danger">DELETE</span> <code>https://api.radar.io/v1/geofences/:id</code>
+<br />
 <span className="badge badge--danger">DELETE</span> <code>https://api.radar.io/v1/geofences/:tag/:externalId</code>
 
 ###### Default rate limit
@@ -1827,8 +1829,8 @@ A beacon represents a bluetooth beacon in your project. Beacons can be uniquely 
 - **`externalId`** (optional, but recommended): An external ID for the beacon.
 - **`type`** (required): The type of beacon. `ibeacon` is currently supported.
 - **`uuid`** (required): The UUID of the beacon.
-- **`majorId`** (required): The major ID of the beacon.
-- **`minorId`** (required): The minor ID of the beacon.
+- **`major`** (required): The major ID of the beacon.
+- **`minor`** (required): The minor ID of the beacon.
 - **`geometry`** (point): The approximate location of the beacon, used to sync nearby beacons (within 1 kilometer) to the SDK. Coordinates for type `point` in `[longitude,latitude]` format.
 - **`enabled`** (required): If true, the beacon will generate events. If false, the beacon will not generate events.
 - **`metadata`** (required): A set of custom key-value pairs for the beacon. A JSON string representing a dictionary with up to 16 keys and values of type string, boolean, or number.
@@ -1921,7 +1923,9 @@ Gets a beacon. The beacon can be uniquely referenced by Radar `id` or by `uuid`,
 
 ###### Definition
 
-<span className="badge badge--success">GET</span> <code>https://api.radar.io/v1/beacons/:id</code><span className="badge badge--success">GET</span> <code>https://api.radar.io/v1/beacons/:uuid/:major/:minor</code>
+<span className="badge badge--success">GET</span> <code>https://api.radar.io/v1/beacons/:id</code>
+<br />
+<span className="badge badge--success">GET</span> <code>https://api.radar.io/v1/beacons/:uuid/:major/:minor</code>
 
 ###### Default rate limit
 
@@ -1971,8 +1975,8 @@ Creates a beacon.
 - **`externalId`** (optional, but recommended): An external ID for the beacon.
 - **`type`** (required): The type of beacon. `ibeacon` is currently supported.
 - **`uuid`** (required): The UUID of the beacon.
-- **`majorId`** (required): The major ID of the beacon.
-- **`minorId`** (required): The minor ID of the beacon.
+- **`major`** (required): The major ID of the beacon.
+- **`minor`** (required): The minor ID of the beacon.
 - **`coordinates`** (point): The approximate location of the beacon, used to sync nearby beacons (within 1 kilometer) to the SDK. Coordinates in `[longitude,latitude]` format.
 - **`enabled`** (required): If true, the beacon will generate events. If false, the beacon will not generate events.
 - **`metadata`** (required): A set of custom key-value pairs for the beacon. A JSON string representing a dictionary with up to 16 keys and values of type string, boolean, or number.

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1829,7 +1829,7 @@ A beacon represents a bluetooth beacon in your project. Beacons can be uniquely 
 - **`uuid`** (required): The UUID of the beacon.
 - **`majorId`** (required): The major ID of the beacon.
 - **`minorId`** (required): The minor ID of the beacon.
-- **`geometry`** (polygon): The approximate location of the beacon, used to sync nearby beacons (within 1 kilometer) to the SDK. Coordinates for type `point` in `[longitude,latitude]` format.
+- **`geometry`** (point): The approximate location of the beacon, used to sync nearby beacons (within 1 kilometer) to the SDK. Coordinates for type `point` in `[longitude,latitude]` format.
 - **`enabled`** (required): If true, the beacon will generate events. If false, the beacon will not generate events.
 - **`metadata`** (required): A set of custom key-value pairs for the beacon. A JSON string representing a dictionary with up to 16 keys and values of type string, boolean, or number.
 
@@ -2000,6 +2000,67 @@ curl "https://api.radar.io/v1/beacons" \
   -d "uuid=f7826da6-4fa2-4e98-0000-bc5b71e0893e" \
   -d "major=2298" \
   -d "minor=8515"
+```
+
+###### Sample response
+
+```json
+{
+    "meta": {
+        "code": 200
+    },
+    "beacon": {
+        "_id": "6116d947049aee0089a682a2",
+        "createdAt": "2021-08-13T20:42:47.711Z",
+        "updatedAt": "2021-08-13T20:42:47.711Z",
+        "live": true,
+        "description": "Beacon 1",
+        "tag": "drive-thru",
+    ...
+  }
+}
+```
+
+#### Upsert a beacon
+
+Upserts a beacon. The beacon can be uniquely referenced by `tag` and `externalId`. If a beacon with the specified `tag` and `externalId` already exists, it will be updated. If not, it will be created.
+
+###### Definition
+
+<span className="badge badge--warning">PUT</span> <code>https://api.radar.io/v1/beacons/:tag/:externalId</code>
+
+###### Body parameters
+
+- **`description`** (string, required): A display name for the beacon.
+- **`type`** (string, required): The type of beacon. `ibeacon` is currently supported.
+- **`uuid`** (string, required): The UUID of the beacon.
+- **`major`** (string, required): The major ID of the beacon.
+- **`minor`** (string, required): The minor ID of the beacon.
+- **`coordinates`** (point, required): The approximate location of the beacon, used to sync nearby beacons (within 1 kilometer) to the SDK. Coordinates in `[longitude,latitude]` format.
+- **`metadata`** (dictionary, optional): An optional set of custom key-value pairs for the beacon. A JSON string representing a dictionary with up to 16 keys and values of type string, boolean, or number.
+- **`enabled`** (boolean, optional): If `true`, the beacon will generate events. If `false`, the beacon will not generate events. Defaults to `true`.
+
+###### Default rate limit
+
+10 requests per second
+
+###### Authentication level
+
+Secret
+
+###### Sample request
+
+```bash
+curl "https://api.radar.io/v1/drive-thru/store123-beacon-1" \
+  -H "Authorization: prj_live_sk_..." \
+  -X PUT \
+  -d "description=Beacon 1" \
+  -d "type=ibeacon" \
+  -d "uuid=f7826da6-4fa2-4e98-0000-bc5b71e0893e" \
+  -d "major=2298" \
+  -d "minor=8515" \
+  -d "coordinates=[-105.94653744704361,35.70654086799666]" \
+  -d "enabled=true"
 ```
 
 ###### Sample response

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -2055,7 +2055,7 @@ Secret
 ###### Sample request
 
 ```bash
-curl "https://api.radar.io/v1/drive-thru/store123-beacon-1" \
+curl "https://api.radar.io/v1/beacons/drive-thru/store123-beacon-1" \
   -H "Authorization: prj_live_sk_..." \
   -X PUT \
   -d "description=Beacon 1" \

--- a/docs/beacons.mdx
+++ b/docs/beacons.mdx
@@ -100,7 +100,7 @@ You can also create beacons programmatically via the [API](/api). You can create
 For example, to upsert a beacon within a store via the [API](/api):
 
 ```bash
-curl "https://api.radar.io/v1/drive-thru/store123-beacon-1" \
+curl "https://api.radar.io/v1/beacons/drive-thru/store123-beacon-1" \
     -H "Authorization: prj_live_sk_..." \
     -X PUT \
     -d "description=Beacon 1" \

--- a/docs/beacons.mdx
+++ b/docs/beacons.mdx
@@ -15,8 +15,8 @@ Beacons provides the following user context:
   beacons: [
     {
       uuid: "b9407f30-f5f8-466e-aff9-25556b57fe6d",
-      majorId: "100",
-      minorId: "1",
+      major: "100",
+      minor: "1",
       description: "Store #123 - Register #1",
       tag: "store-register",
       externalId: "1",
@@ -24,8 +24,8 @@ Beacons provides the following user context:
     },
     {
       uuid: "c9407f30-f5f8-466e-aff9-25556b57fe6d",
-      majorId: "100",
-      minorId: "2",
+      major: "100",
+      minor: "2",
       description: "Store #123 - Register #2",
       tag: "store-register",
       externalId: "123-2",
@@ -54,15 +54,23 @@ To range beacons, the user must grant location permissions. If the user grants f
 
 Beacon entry and exit events are sent to the SDK, to [webhooks](/integrations#webhooks), and to [integrations](/integrations) just like geofence entry and exit events.
 
-## CSV import
+## Create beacons
 
-Like [geofences](/geofences), you also specify the metadata for beacons when you create them, including *tag* (an optional group for the geofence, e.g., `store-register`), external ID (an optional external ID for the beacon that maps to your internal database, e.g., `123-1`), *description* (a display name for the beacon, e.g., `Store #123 - Register #1`).
+You can create beacons via the dashboard, CSV import, or through the API. You can create beacons in the Test environment for development and testing, and in the Live environment for production.
 
-You also specify the identifiers used to range the beacon, including `uuid`, `majorId`, and `minorId`, as well as an approximate latitude and longitude used to sync nearby beacons (within 1 kilometer) to the SDK.
+Like [geofences](/geofences), you also specify the metadata for beacons when you create them, including *tag* (a group for the beacon, e.g., `store-register`), external ID (an external ID for the beacon that maps to your internal database, e.g., `123-1`), *description* (a display name for the beacon, e.g., `Store #123 - Register #1`).
+
+You also specify the identifiers used to range the beacon, including `uuid`, `major`, and `minor`, as well as an approximate latitude and longitude used to sync nearby beacons (within 1 kilometer) to the SDK.
 
 **Beacons should be uniquely referenced by tag and external ID, assigned by you when a beacon is created. To disable or rotate identifiers for a beacon, re-import the beacon with the same tag and external ID.**
 
-To import beacons, go to the [Beacons page](https://radar.io/dashboard/beacons) and click the *Import* button. Then, select a CSV to upload.
+### Dashboard
+
+To create a beacon via the dashboard, go to the [Beacons page](https://radar.io/dashboard/beacons) and click the _New_ button. Enter a description, type, tag, external ID, UUID, major, minor, and optional metadata. Click _Create_ to create the beacon.
+
+### CSV import
+
+To import beacons via CSV import, go to the [Beacons page](https://radar.io/dashboard/beacons) and click the *Import* button. Then, select a CSV to upload.
 
 The CSV must have 8 columns:
 
@@ -71,8 +79,8 @@ The CSV must have 8 columns:
 - **`externalId`** (optional, but recommended): An external ID for the beacon that maps to your internal database.
 - **`type`** (required): The type of beacon. `ibeacon` is currently supported.
 - **`uuid`** (required): The UUID of the beacon.
-- **`majorId`** (required): The major ID of the beacon.
-- **`minorId`** (required): The minor ID of the beacon.
+- **`major`** (required): The major ID of the beacon.
+- **`minor`** (required): The minor ID of the beacon.
 - **`coordinates`** (required): The approximate location of the beacon, used to sync nearby beacons (within 1 kilometer) to the SDK. A JSON string in the format `[longitude,latitude]`. **Note that longitude comes before latitude, a GeoJSON convention.**
 - **`enabled`** (required): If true, the beacon will generate events. If false, the beacon will not generate events.
 - **`metadata`** (required): A set of custom key-value pairs for the beacon. A JSON string representing a dictionary with up to 16 keys and values of type string, boolean, or number.
@@ -89,3 +97,23 @@ For example, to import beacons installed on registers and in parking spaces at a
 "Store #123 - Parking Space #1",store-parking,123-1,ibeacon,"d9407f30-f5f8-466e-aff9-25556b57fe6d",101,1,"[-73.975363,40.783826]",true,{}
 "Store #123 - Parking Space #2",store-parking,123-2,ibeacon,"e9407f30-f5f8-466e-aff9-25556b57fe6d",101,2,"[-73.975363,40.783826]",true,{}
 ```
+
+### API
+You can also create beacons programmatically via the [API](/api). You can create a beacon via <span className="badge badge--info">POST</span> `/api/v1/beacons`, or upsert a beacon based on tag and external ID via <span className="badge badge--warning">PUT</span> `/api/v1/beacons/:tag/:externalId`.
+
+For example, to upsert a beacon within a store via the [API](/api):
+
+```bash
+curl "https://api.radar.io/v1/drive-thru/store123-beacon-1" \
+    -H "Authorization: prj_live_sk_..." \
+    -X PUT \
+    -d "description=Beacon 1" \
+    -d "type=ibeacon" \
+    -d "uuid=f7826da6-4fa2-4e98-0000-bc5b71e0893e" \
+    -d "major=2298" \
+    -d "minor=8515" \
+    -d "coordinates=[-105.94653744704361,35.70654086799666]" \
+    -d "enabled=true"
+```
+
+**Again, note that longitude comes before latitude, a GeoJSON convention.**

--- a/docs/beacons.mdx
+++ b/docs/beacons.mdx
@@ -56,17 +56,13 @@ Beacon entry and exit events are sent to the SDK, to [webhooks](/integrations#we
 
 ## Create beacons
 
-You can create beacons via the dashboard, CSV import, or through the API. You can create beacons in the Test environment for development and testing, and in the Live environment for production.
+You can create beacons via CSV import or through the API. You can create beacons in the Test environment for development and testing, and in the Live environment for production.
 
 Like [geofences](/geofences), you also specify the metadata for beacons when you create them, including *tag* (a group for the beacon, e.g., `store-register`), external ID (an external ID for the beacon that maps to your internal database, e.g., `123-1`), *description* (a display name for the beacon, e.g., `Store #123 - Register #1`).
 
 You also specify the identifiers used to range the beacon, including `uuid`, `major`, and `minor`, as well as an approximate latitude and longitude used to sync nearby beacons (within 1 kilometer) to the SDK.
 
 **Beacons should be uniquely referenced by tag and external ID, assigned by you when a beacon is created. To disable or rotate identifiers for a beacon, re-import the beacon with the same tag and external ID.**
-
-### Dashboard
-
-To create a beacon via the dashboard, go to the [Beacons page](https://radar.io/dashboard/beacons) and click the _New_ button. Enter a description, type, tag, external ID, UUID, major, minor, and optional metadata. Click _Create_ to create the beacon.
 
 ### CSV import
 

--- a/docs/geofences.mdx
+++ b/docs/geofences.mdx
@@ -96,7 +96,7 @@ For example, to upsert a geofence representing a store via the [API](/api):
 
 ```bash
 curl https://api.radar.io/v1/geofences/store/123 \
-    -H "Authorization: prj_live_sk_8ca5fdbe82ab7d49a1ca5c3f" \
+    -H "Authorization: prj_live_sk_..." \
     -X PUT \
     -d "description=Store #123" \
     -d "type=circle" \


### PR DESCRIPTION
## What?
- Adding documentation for Upserting a Beacon to API Reference
- Moving multiple API definitions to individual lines w/ line breaks between
- Revamping the Beacons page to be more like Geofences
    - Adding a `Create Beacons` sections w/ `CSV Import` and `API` sections as opposed to just `CSV Import`

## Why?
- Additions to the Radar API
- Cleaning up existing sections

## Screenshots (optional)

### Upserting a Beacon in API Reference
![image](https://user-images.githubusercontent.com/32653448/142246716-b545cdcd-4354-45fb-bead-642b5cdef08f.png)

![image](https://user-images.githubusercontent.com/32653448/142246736-8d071922-a836-4908-a40c-b0797ed7f6c0.png)

### Moving multiple definitions to individual lines
There were a few instances of this, but here is just one example

#### Before
![image](https://user-images.githubusercontent.com/32653448/142271721-b56b91c7-3486-46ae-af6a-39fceed5a731.png)

#### After
![image](https://user-images.githubusercontent.com/32653448/142271663-7fa4028d-81da-439d-aa9e-1a6f10f3110b.png)

### Revamping the Beacons page to be more like Geofences
![image](https://user-images.githubusercontent.com/32653448/142658699-51a27462-117a-4567-93c2-238cde2458ab.png)

![image](https://user-images.githubusercontent.com/32653448/142272371-410d291b-82bf-4cce-be52-d8f415578628.png)
