### PR TITLE
Update Capacitor docs to includes log listener

### DIFF
--- a/docs/sdk/capacitor.mdx
+++ b/docs/sdk/capacitor.mdx
@@ -246,6 +246,10 @@ Radar.addListener('events', (result) => {
 Radar.addListener('error', (result) => {
   // do something with result.err
 });
+
+Radar.addListener('log', (result) => {
+  // do something with result.message
+});
 ```
 
 Add event listeners outside of your view lifecycle if you want them to work when the app is in the background.


### PR DESCRIPTION
## What?

Add log listener to capacitor docs

## Why?

It is missing.