### PR TITLE
Update data retention to self serve

### DIFF
--- a/docs/faqs.mdx
+++ b/docs/faqs.mdx
@@ -83,7 +83,7 @@ For more information, see our [location data privacy checklist](https://radar.co
 
 By default, users and events are retained for 1 year, trips are retained for 90 days, and location updates are retained for 7 days.
 
-Radar supports custom data retention policies for enterprise customers. Contact your customer success manager to enable this feature.
+Radar supports custom data retention policies for enterprise customers. Admins can adjust these settings in your Radar dashboard under the Privacy section.
 
 ### Is Radar CCPA-compliant and GDPR-compliant?
 


### PR DESCRIPTION
## What?
Update FAQ to indicate customers can change their own data retention settings.

## Why?
We added self service data retention adjustments.
