### PR TITLE
Include listeners in Xamarin docs

### DIFF
--- a/docs/sdk/xamarin.mdx
+++ b/docs/sdk/xamarin.mdx
@@ -139,7 +139,7 @@ To listen for events, location updates, and errors, you can add event listeners:
 ```cs
 Radar.ClientLocationUpdated += (result) =>
 {
-// do something with result.location, result.stopped, result.source
+    // do something with result.location, result.stopped, result.source
 };
 
 Radar.LocationUpdated += (result) =>
@@ -149,7 +149,7 @@ Radar.LocationUpdated += (result) =>
 
 Radar.EventsReceived += (result) =>
 {
-  // do something with result.events, result.user
+    // do something with result.events, result.user
 };
 
 Radar.Error += (err) => {

--- a/docs/sdk/xamarin.mdx
+++ b/docs/sdk/xamarin.mdx
@@ -134,6 +134,30 @@ Radar.StopTracking();
 
 Learn about platform-specific implementations of these functions in the [iOS SDK documentation](/sdk/ios) and [Android SDK documentation](/sdk/android).
 
+To listen for events, location updates, and errors, you can add event listeners:
+
+```cs
+Radar.ClientLocationUpdated += (result) =>
+{
+// do something with result.location, result.stopped, result.source
+};
+
+Radar.LocationUpdated += (result) =>
+{
+    // do something with result.location, result.user
+};
+
+Radar.EventsReceived += (result) =>
+{
+  // do something with result.events, result.user
+};
+
+Radar.Error += (err) => {
+    // do something with err
+};
+
+```
+
 ### Mock tracking
 
 On iOS and Android, you can simulate a sequence of location updates for testing. For example, to simulate a sequence of 10 location updates every 3 seconds by car from an `origin` to a `destination`, we can call:


### PR DESCRIPTION
## What?

Include information on the Xamarin event listeners exposed in the SDK

## Why?

Currently not documented
