### PR TITLE
[Fixit] Use Inclusive Language in Docs

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -38,7 +38,7 @@ The API uses standard HTTP response codes.
 - **`404`**: Not found
 - **`409`**: Conflict
 - **`429`**: Too many requests (rate limit exceeded, no state change, or selective throttling)
-- **`451`**: Unavailable for legal reasons (country blacklisted)
+- **`451`**: Unavailable for legal reasons (country blocklisted)
 - **`500`**: Internal server error
 - **`503`**: Service temporarily unavailable
 

--- a/docs/integrations.mdx
+++ b/docs/integrations.mdx
@@ -90,9 +90,9 @@ Click *Show Advanced* on the [Integrations page](https://radar.com/dashboard/int
 
 To filter event types sent to an integration, select or unselect event types under *Event Type Whitelist*.
 
-To filter keys from the request body sent to an integration, add keys, comma-separated, to *Request Key Blacklist*. For example, to skip sending `radar_geofence_ids` to the Segment `identify` call and to skip sending `geofence_id` to the Segment `track` call, add `radar_geofence_ids,geofence_id` to *Request Key Blacklist*.
+To filter keys from the request body sent to an integration, add keys, comma-separated, to *Request Key Blocklist*. For example, to skip sending `radar_geofence_ids` to the Segment `identify` call and to skip sending `geofence_id` to the Segment `track` call, add `radar_geofence_ids,geofence_id` to *Request Key Blocklist*.
 
-To filter events sent to an integration based upon a [Geofence](/documentation/geofences) tag, add tags, comma-separated to *Geofence Tag Blacklist*. For example, to skip sending all events to the Amplitude integration for geofences tagged `gas-station` and `cafe`, add `gas-station,cafe` to *Geofence Tag Blacklist*.
+To filter events sent to an integration based upon a [Geofence](/documentation/geofences) tag, add tags, comma-separated to *Geofence Tag Blocklist*. For example, to skip sending all events to the Amplitude integration for geofences tagged `gas-station` and `cafe`, add `gas-station,cafe` to *Geofence Tag Blocklist*.
 
 ## Geofence integrations
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -53,7 +53,7 @@ Geofencing turns location data into context and events to help you build context
         <img src="https://images.ctfassets.net/f2vbu16fzuly/1hDJzlo8jqh8mWNGmxlLrm/b68061f89a24c683d4c87d8525370144/regions.svg" />
       }
     >
-      Detect a user's country, state, DMA (market area), and postal code. Change the app experience based on region, or blacklist location updates in specific countries or states for compliance reasons.
+      Detect a user's country, state, DMA (market area), and postal code. Change the app experience based on region, or blocklist location updates in specific countries or states for compliance reasons.
     </IconCard>
   </LinkCard>
 

--- a/docs/regions.mdx
+++ b/docs/regions.mdx
@@ -48,9 +48,9 @@ Regions is available on the [Team](https://radar.com/pricing) plan and higher.
 
 Regions supports country detection globally. Each country has a `name` and a unique 2-letter [ISO 3166](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes) `code`. View the [full list of countries](/regions/countries).
 
-### Country whitelist or blacklist
+### Country allowlist or blocklist
 
-Regions can also be used to whitelist or blacklist location updates in specific countries for privacy or compliance reasons. Contact your customer success manager to enable this feature.
+Regions can also be used to allowlist or blocklist location updates in specific countries for privacy or compliance reasons. Contact your customer success manager to enable this feature.
 
 ## States
 


### PR DESCRIPTION
## What?
Replace `blacklist` with `blocklist` and `whitelist` with `allowlist` to mirror frontend changes to use more inclusive terminology.

## Why?
We're replacing certain terms in the web application to use [more inclusive terminology](https://v8.dev/docs/respectful-code#:~:text=Inclusivity%20is%20central%20to%20V8's,documentation%20can%20perpetuate%20that%20discrimination.) and should keep documentation on par with those changes.