### PR TITLE
remove explicit stopForegroundService() call

### DIFF
--- a/docs/sdk/android.mdx
+++ b/docs/sdk/android.mdx
@@ -408,7 +408,6 @@ To stop tracking (e.g., when the user logs out), call:
 
   ```java
   Radar.stopTracking();
-  stopForegroundService();
   ```
 
   </TabItem>
@@ -416,7 +415,6 @@ To stop tracking (e.g., when the user logs out), call:
 
   ```kotlin
   Radar.stopTracking()
-  stopForegroundService()
   ```
 
   </TabItem>


### PR DESCRIPTION
To be consistent with removing the `startForegroundService()` call from https://github.com/radarlabs/documentation/pull/89

The Radar SDK now manages the starting / stopping of a foreground service in continuous mode