### PR TITLE
update background modes

### DIFF
--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -317,7 +317,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
 
 ### Background modes
 
-If you are planning to leverage background tracking, such as responsive or continuous modes, in your project settings, go to _Signing & Capabilities_, add _Background Modes_, and turn on _Background fetch_ and _Location updates_. Note that this requires additional justification during App Store review. Learn more [below](#submit-to-app-store).
+If you are planning to leverage background tracking, such as responsive or continuous mode, in your project settings, go to _Signing & Capabilities_, add _Background Modes_, and turn on _Background fetch_ and _Location updates_. Note that this requires additional justification during App Store review. Learn more [below](#submit-to-app-store).
 
 <img
   className="large"

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -315,7 +315,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
   settings to make sure you haven't already granted location permissions.
 </Alert>
 
-If you are requesting background permissions, in your project settings, go to _Signing & Capabilities_, add _Background Modes_, and turn on _Background fetch_ and _Location updates_. Note that this requires additional justification during App Store review. Learn more [below](#submit-to-app-store).
+### Background modes
+
+If you are planning to leverage background tracking, such as with responsive or continuous modes, go to your project settings, _Signing & Capabilities_, add _Background Modes_, and turn on _Background fetch_ and _Location updates_. Note that this requires additional justification during App Store review. Learn more [below](#submit-to-app-store).
 
 <img
   className="large"

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -317,7 +317,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
 
 ### Background modes
 
-If you are planning to leverage background tracking, such as with responsive or continuous modes, go to your project settings, _Signing & Capabilities_, add _Background Modes_, and turn on _Background fetch_ and _Location updates_. Note that this requires additional justification during App Store review. Learn more [below](#submit-to-app-store).
+If you are planning to leverage background tracking, such as responsive or continuous modes, in your project settings, go to _Signing & Capabilities_, add _Background Modes_, and turn on _Background fetch_ and _Location updates_. Note that this requires additional justification during App Store review. Learn more [below](#submit-to-app-store).
 
 <img
   className="large"

--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -37,7 +37,7 @@ You must add location usage descriptions and background modes to your `Info.plis
   src="https://images.ctfassets.net/f2vbu16fzuly/66LUD7W9uTt7f2H5pMmpBp/1e5a2bb2baaf79328e88c3ea47a7f6ff/permissions.png"
 />
 
-If you are planning to leverage background tracking, such as responsive or continuous modes, in your project settings, go to _Signing & Capabilities_, add _Background Modes_, and turn on _Background fetch_ and _Location updates_. Note that this requires additional justification during App Store review. [Learn more](/sdk/ios#submit-to-app-store).
+If you are planning to leverage background tracking, such as responsive or continuous mode, in your project settings, go to _Signing & Capabilities_, add _Background Modes_, and turn on _Background fetch_ and _Location updates_. Note that this requires additional justification during App Store review. [Learn more](/sdk/ios#submit-to-app-store).
 
 <img
   className="large"

--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -37,7 +37,7 @@ You must add location usage descriptions and background modes to your `Info.plis
   src="https://images.ctfassets.net/f2vbu16fzuly/66LUD7W9uTt7f2H5pMmpBp/1e5a2bb2baaf79328e88c3ea47a7f6ff/permissions.png"
 />
 
-If you are requesting background permissions, in your project settings, go to _Signing & Capabilities_, add _Background Modes_, and turn on _Background fetch_ and _Location updates_. Note that this requires additional justification during App Store review. [Learn more](/sdk/ios#submit-to-app-store).
+If you are planning to leverage background tracking, such as responsive or continuous modes, in your project settings, go to _Signing & Capabilities_, add _Background Modes_, and turn on _Background fetch_ and _Location updates_. Note that this requires additional justification during App Store review. [Learn more](/sdk/ios#submit-to-app-store).
 
 <img
   className="large"


### PR DESCRIPTION
## What?

Make background modes iOS documentation more prominent and accurate

## Why?

The current documentation is not clear on which tracking modes require this change. Additionally, it is nested under permissions and could easily be missed by developers.
