### PR TITLE
Update FAQ to include iOS 15+ simulated location flag

### DIFF
--- a/docs/faqs.mdx
+++ b/docs/faqs.mdx
@@ -45,7 +45,7 @@ Yes, Radar supports location verification and fraud detection for gambling, medi
 
 First, you can use the [IP geocoding API](/api#ip-geocode) to detect a user's country or state based on IP address. You can check the `proxy` flag in the response to determine if the user is using a known proxy, VPN, data center, or Tor exit node.
 
-Second, you can use [Regions](/regions) to detect a user's country or state based on latitude and longitude. On Android, you can check the [`location.isMock`](https://developer.android.com/reference/android/location/Location#isMock()) flag determine if the user is mocking their location.
+Second, you can use [Regions](/regions) to detect a user's country or state based on latitude and longitude. On Android, you can check the [`location.isMock`](https://developer.android.com/reference/android/location/Location#isMock()) flag, and on iOS 15 and above, you can use the [`location.sourceInformation.isSimulatedBySoftware`](https://developer.apple.com/documentation/corelocation/cllocationsourceinformation/3861807-issimulatedbysoftware) flag to determine if the user is mocking their location.
 
 ## Privacy
 


### PR DESCRIPTION
## What?
As of iOS 15, a new property, [`isSimulatedBySoftware`](developer.apple.com/documentation/corelocation/cllocationsourceinformation/3861807-issimulatedbysoftware), has been added to `CLLocationSourceInformation`. This value is comparable to Android's `isMock()` and should be noted in the documentation alongside it.

## How?
Updated the "location verification or fraud detection" section of faqs.mdx
