### PR TITLE
add custom chain id usage in search api

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -750,7 +750,7 @@ Searches for places near a location, sorted by distance.
 
 ###### Query parameters
 
-- **`chains`** (string, optional): [Chain slug](/places#chains) filters. A string, comma-separated. If a [chain mapping](/places#mappings) exists, the mapped ID can be used in place of the chain slug. If not provided, one of `categories` or `groups` must be provided.
+- **`chains`** (string, optional): [Chain slug](/places#chains) filters. A string, comma-separated. If your project has a [chain mapping](/places#mappings), the mapped ID can be used in place of the chain slug. If not provided, one of `categories` or `groups` must be provided.
 - **`categories`** (string, optional): [Category](/places#categories) filters. A string, comma-separated. If not provided, one of `chains` or `groups` must be provided.
 - **`groups`** (string, optional): [Group](/places#groups) filters. A string, comma-separated. If not provided, one of `chains` or `categories` must be provided.
 - **`chainMetadata[key]`** (optional): Optional [chain metadata](/places#metadata) filters. Values may be of type string, boolean, or number. Type will be automatically inferred. For example, to match on `offers == true`, use `&chainMetadata[offers]=true`.

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -750,7 +750,7 @@ Searches for places near a location, sorted by distance.
 
 ###### Query parameters
 
-- **`chains`** (string, optional): [Chain slug](/places#chains) filters. A string, comma-separated. If not provided, one of `categories` or `groups` must be provided.
+- **`chains`** (string, optional): [Chain Slug](/places#chains) or [Chain Mapping](/places#mappings) filters. A string, comma-separated. If not provided, one of `categories` or `groups` must be provided.
 - **`categories`** (string, optional): [Category](/places#categories) filters. A string, comma-separated. If not provided, one of `chains` or `groups` must be provided.
 - **`groups`** (string, optional): [Group](/places#groups) filters. A string, comma-separated. If not provided, one of `chains` or `categories` must be provided.
 - **`chainMetadata[key]`** (optional): Optional [chain metadata](/places#metadata) filters. Values may be of type string, boolean, or number. Type will be automatically inferred. For example, to match on `offers == true`, use `&chainMetadata[offers]=true`.

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -750,7 +750,7 @@ Searches for places near a location, sorted by distance.
 
 ###### Query parameters
 
-- **`chains`** (string, optional): [Chain Slug](/places#chains) or [Chain Mapping](/places#mappings) filters. A string, comma-separated. If not provided, one of `categories` or `groups` must be provided.
+- **`chains`** (string, optional): [Chain slug](/places#chains) filters. A string, comma-separated. If a [chain mapping](/places#mappings) exists, the mapped ID can be used in place of the chain slug. If not provided, one of `categories` or `groups` must be provided.
 - **`categories`** (string, optional): [Category](/places#categories) filters. A string, comma-separated. If not provided, one of `chains` or `groups` must be provided.
 - **`groups`** (string, optional): [Group](/places#groups) filters. A string, comma-separated. If not provided, one of `chains` or `categories` must be provided.
 - **`chainMetadata[key]`** (optional): Optional [chain metadata](/places#metadata) filters. Values may be of type string, boolean, or number. Type will be automatically inferred. For example, to match on `offers == true`, use `&chainMetadata[offers]=true`.

--- a/docs/places.mdx
+++ b/docs/places.mdx
@@ -6,7 +6,7 @@ id: places
 import Alert from "../src/components/Alert";
 
 <Alert alertType="info">
-  Places is available on the {` `} 
+  Places is available on the {` `}
   <a href="https://radar.com/pricing" target="_blank">Enterprise plan</a>
   .
 </Alert>
@@ -111,7 +111,7 @@ For example, to map `burger-king` to `123` and `mcdonalds` to `456`:
 { "burger-king": "123", "mcdonalds": "456" }
 ```
 
-Custom chain IDs will be exposed as `place.chain.externalId` in user context and events. Chain IDs can also be used in place of chain slugs when performing searches with the [search places API](/api#search-places).
+Custom chain IDs will be exposed as `place.chain.externalId` in user context and events. These custom IDs can also be used in place of chain slugs when performing searches with the [search places API](/api#search-places).
 
 ### Metadata
 

--- a/docs/places.mdx
+++ b/docs/places.mdx
@@ -111,7 +111,7 @@ For example, to map `burger-king` to `123` and `mcdonalds` to `456`:
 { "burger-king": "123", "mcdonalds": "456" }
 ```
 
-Custom chain IDs will be exposed as `place.chain.externalId` in user context and events.
+Custom chain IDs will be exposed as `place.chain.externalId` in user context and events. Chain IDs can also be used in place of chain slugs when performing searches with the [search places API](/api#search-places).
 
 ### Metadata
 


### PR DESCRIPTION
## What?
Chain ID's that are specified in **Setttings** > **Chain Mappings** can be used in the API's in place of a chain slug.

## Why?
Undocumented functionality.

## How?
I setup a mapping in my personal account and tested that the ID's specified could be used in an 'Search Places' API request via Postman.
