### PR TITLE
New Xamarin import syntax

### DIFF
--- a/docs/sdk/xamarin.mdx
+++ b/docs/sdk/xamarin.mdx
@@ -25,7 +25,8 @@ If you have an iOS and an Android project, add the package to each project.
 First, initialize the SDK:
 
 ```cs
-using RadarIO.Xamarin
+using static RadarIO.Xamarin.RadarSingleton;
+
 namespace MyProject
 {
     public class Example


### PR DESCRIPTION
From a support finding, there's a new C# syntax that imports all the static properties of a namespace - here's the [slack thread](https://radarlabs.slack.com/archives/C02A30H0UC9/p1646267185179719)

Also matches the syntax used in our [Android](https://github.com/radarlabs/radar-sdk-xamarin/blob/e2ad099a10b588a5f93bae3564436e03cd6af001/Samples/RadarIO.Xamarin.Android.Sample/MainActivity.cs#L12) and [iOS](https://github.com/radarlabs/radar-sdk-xamarin/blob/e2ad099a10b588a5f93bae3564436e03cd6af001/Samples/RadarIO.Xamarin.iOS.Sample/ViewController.cs#L7) examples