### PR TITLE
updates to setForegroundServiceOptions for cross platform libs

### DIFF
--- a/docs/sdk/cordova.mdx
+++ b/docs/sdk/cordova.mdx
@@ -167,6 +167,17 @@ You only need to call these methods once, as these settings will be persisted ac
 Though we recommend using presets for most use cases, you can customize the tracking options. See the [tracking options reference](/sdk/tracking).
 
 ```javascript
+// optionally adjust foreground service options for android
+cordova.plugins.radar.setForegroundServiceOptions({
+  options: {
+    text: "Location tracking started",
+    title: "Location updates",
+    updatesOnly: false,
+    importance: 2,
+    activity: 'com.yourapp.MainActivity'
+  }
+});
+
 cordova.plugins.radar.startTrackingCustom({
   desiredStoppedUpdateInterval: 180,
   desiredMovingUpdateInterval: 60,
@@ -176,7 +187,8 @@ cordova.plugins.radar.startTrackingCustom({
   stopDistance: 70,
   sync: 'all',
   replay: 'none',
-  showBlueBar: true
+  showBlueBar: true,
+  foregroundServiceEnabled: true,
 });
 ```
 

--- a/docs/sdk/cordova.mdx
+++ b/docs/sdk/cordova.mdx
@@ -188,7 +188,7 @@ cordova.plugins.radar.startTrackingCustom({
   sync: 'all',
   replay: 'none',
   showBlueBar: true,
-  foregroundServiceEnabled: true,
+  foregroundServiceEnabled: true
 });
 ```
 


### PR DESCRIPTION
## What?

Showing how to adjust default options on foreground service for custom tracking

## Why?

Stale documentation for these two SDKs