### PR TITLE
typos and minor fixes from my onboarding diary

### DIFF
--- a/docs/toolkit.mdx
+++ b/docs/toolkit.mdx
@@ -40,7 +40,7 @@ To get started, you'll need a Radar account. Don't have a Radar account yet? [Si
 
 2. Open the app and grant notification permissions and location permissions.
 
-3. Copy your `Test Publishable` key from the *Keys* section of the [Settings page](https://radar.com/settings) and paste it into the app.
+3. Copy your `Test Publishable` key from the *Keys* section of the Settings page and paste it into the app.
 
 4. To track in the background, turn on *Tracking* (it is on by default). Then, select the *Tracking Options* preset to use, one of *Efficient*, *Responsive*, or *Continuous*. Learn about [iOS tracking presets](/sdk/tracking#ios-presets) and [Android tracking presets](/sdk/tracking#android-presets). Finally, on the notifications you want to receive, including *Events* (events received from Radar), *Locations* (location updates sent to Radar), and *Errors* (network, location, and permissions errors).
 

--- a/docs/toolkit.mdx
+++ b/docs/toolkit.mdx
@@ -40,14 +40,16 @@ To get started, you'll need a Radar account. Don't have a Radar account yet? [Si
 
 2. Open the app and grant notification permissions and location permissions.
 
-3. Copy your `Test Publishable` key from the *Keys* section of the Settings page and paste it into the app.
+3. Copy your `Test Publishable` key from the *Keys* section of the [Get Started page](https://radar.com/dashboard) and paste it into the app.
 
-4. To track in the background, turn on *Tracking* (it is on by default). Then, select the *Tracking Options* preset to use, one of *Efficient*, *Responsive*, or *Continuous*. Learn about [iOS tracking presets](/sdk/tracking#ios-presets) and [Android tracking presets](/sdk/tracking#android-presets). Finally, on the notifications you want to receive, including *Events* (events received from Radar), *Locations* (location updates sent to Radar), and *Errors* (network, location, and permissions errors).
+4. Open the *Settings* screen.
 
-5. Close the *Settings* screen.
+5. To track in the background, turn on *Tracking* (it is on by default). Then, select the *Tracking Options* preset to use, one of *Efficient*, *Responsive*, or *Continuous*. Learn about [iOS tracking presets](/sdk/tracking#ios-presets) and [Android tracking presets](/sdk/tracking#android-presets). Finally, turn on the notifications you want to receive, including *Events* (events received from Radar), *Locations* (location updates sent to Radar), and *Errors* (network, location, and permissions errors).
 
-6. To track once in the foreground, tap the refresh button! **If you correctly granted permissions and pasted your API key, and if you have connectivity, you will see your current state in the app and see your user on the [Users page](https://radar.com/users) in the dashboard.** If you are in a geofence or at a place, you will see events in the app and see events on the [Events page](https://radar.com/events) in the dashboard.
+6. Close the *Settings* screen.
 
-6. To track in the background, move more than 100 meters! Depending on the *Tracking Options* preset you selected, your location will update in the background. **Note that location updates may be delayed significantly by Android [Doze Mode and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby.html), iOS [Low Power Mode](https://support.apple.com/en-us/HT205234), or if the device has connectivity issues, low battery, or wi-fi disabled.**
+7. To track once in the foreground, tap the refresh button! **If you correctly granted permissions and pasted your API key, and if you have connectivity, you will see your current state in the app and see your user on the [Users page](https://radar.com/users) in the dashboard.** If you are in a geofence or at a place, you will see events in the app and see events on the [Events page](https://radar.com/events) in the dashboard.
+
+8. To track in the background, move more than 100 meters! Depending on the *Tracking Options* preset you selected, your location will update in the background. **Note that location updates may be delayed significantly by Android [Doze Mode and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby.html), iOS [Low Power Mode](https://support.apple.com/en-us/HT205234), or if the device has connectivity issues, low battery, or wi-fi disabled.**
 
 <img src="https://s3.amazonaws.com/com.onradar.www/images/toolkit_small.png" className="large" />

--- a/docs/trip-tracking.mdx
+++ b/docs/trip-tracking.mdx
@@ -29,7 +29,7 @@ Want to get started quickly? Follow these three steps:
 
 ## Starting trips
 
-Integrate the [SDK](/sdk) into your app or website. When a order starts or the user taps "I'm on my way," start tracking and start a trip with an ID, a destination geofence, a travel mode, and custom metadata (e.g., customer name, car model, or license plate) depending on your use case.
+Integrate the [SDK](/sdk) into your app or website. When an order starts or the user taps "I'm on my way," start tracking and start a trip with an ID, a destination geofence, a travel mode, and custom metadata (e.g., customer name, car model, or license plate) depending on your use case.
 
 <Tabs
   groupId="trip-tracking"

--- a/docs/tutorials/building-a-delivery-tracker-with-live-location-and-etas.mdx
+++ b/docs/tutorials/building-a-delivery-tracker-with-live-location-and-etas.mdx
@@ -28,7 +28,7 @@ If you haven't already, sign up for Radar to get your API key. You can create up
 
 When a delivery is placed, call the [geofence upsert API](/api#upsert-a-geofence) to create a geofence for the delivery. In this case, use `delivery` for the geofence `tag` and the delivery ID for the geofence `externalId`.
 
-Optionally, set `disableAfter` to disable geofence entry events the delivery time, and set `userId` to the user ID of the delivery driver to enable geofence entry events only for that delivery driver.
+Optionally, set `disableAfter` to disable geofence entry events after the delivery time, and set `userId` to the user ID of the delivery driver to enable geofence entry events only for that delivery driver.
 
 ```bash
 curl "https://api.radar.io/v1/geofences/delivery/123" \

--- a/docs/tutorials/building-a-delivery-tracker-with-live-location-and-etas.mdx
+++ b/docs/tutorials/building-a-delivery-tracker-with-live-location-and-etas.mdx
@@ -28,7 +28,7 @@ If you haven't already, sign up for Radar to get your API key. You can create up
 
 When a delivery is placed, call the [geofence upsert API](/api#upsert-a-geofence) to create a geofence for the delivery. In this case, use `delivery` for the geofence `tag` and the delivery ID for the geofence `externalId`.
 
-Optionally, set `disableAfter` to disable geofence entry events the delivery date, and set `userId` to the user ID of the delivery driver to enable geofence entry events only for that delivery driver.
+Optionally, set `disableAfter` to disable geofence entry events the delivery time, and set `userId` to the user ID of the delivery driver to enable geofence entry events only for that delivery driver.
 
 ```bash
 curl "https://api.radar.io/v1/geofences/delivery/123" \
@@ -42,7 +42,7 @@ curl "https://api.radar.io/v1/geofences/delivery/123" \
   -d "userId=456"
 ```
 
-If you do not already have the coordinates the delivery address, you can call the [forward geocode API](/api#forward-geocode) to convert the delivery address to coordinates.
+If you do not already have the coordinates for the delivery address, you can call the [forward geocode API](/api#forward-geocode) to convert the delivery address to coordinates.
 
 ```bash
 curl "https://api.radar.io/v1/geocode/forward?query=20+jay+st+brooklyn+ny" \


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
Putting in minor fixes outlined in my onboarding doc:
- Typos
- Incorrect settings page referenced in toolkit guide - step is referencing app settings in toolkit and not radar settings
- disableAfter can be set for a time, which should be more relevant for real time delivery use cases
<!--
-->

## Why?
Discovered some typos when onboarding
<!--
-->
