### PR TITLE
Add geofence.minimumConfidence to geofence schema

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1633,6 +1633,7 @@ Upserts a geofence. The geofence can be uniquely referenced by `tag` and `extern
 - **`mode`** (string, required for type `isochrone`): The [travel mode](/api#routing) for type `isochrone`.
 - **`tripApproachingThreshold`** (number, optional): The [trip approaching threshold](/trip-tracking#trip-events) setting for the geofence. Overrides the project-level trip approaching threshold setting.
 - **`dwellThreshold`** (number, optional): An optional field to trigger dwell events. If set and `user.dwelled_in_geofence` is enabled in settings, an event is triggered when a user dwells in the geofence longer than the threshold (in minutes).
+- **`geofence.minimumConfidence`** (number, optional): An optional field to limit events to a defined minimal [geofence confidence](https://radar.com/documentation/geofences#confidence-and-accuracy). Use the following values for the minimum confidence level: `3`(high), `2` (medium), `1` (low)
 
 ###### Default rate limit
 

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1633,7 +1633,7 @@ Upserts a geofence. The geofence can be uniquely referenced by `tag` and `extern
 - **`mode`** (string, required for type `isochrone`): The [travel mode](/api#routing) for type `isochrone`.
 - **`tripApproachingThreshold`** (number, optional): The [trip approaching threshold](/trip-tracking#trip-events) setting for the geofence. Overrides the project-level trip approaching threshold setting.
 - **`dwellThreshold`** (number, optional): An optional field to trigger dwell events. If set and `user.dwelled_in_geofence` is enabled in settings, an event is triggered when a user dwells in the geofence longer than the threshold (in minutes).
-- **`geofence.minimumConfidence`** (number, optional): An optional field to limit events to a defined minimal [geofence confidence](https://radar.com/documentation/geofences#confidence-and-accuracy). Use the following values for the minimum confidence level: `3`(high), `2` (medium), `1` (low)
+- **`minimumConfidence`** (number, optional): An optional field to limit events to a defined minimal [geofence confidence](https://radar.com/documentation/geofences#confidence-and-accuracy). Use the following values for the minimum confidence level: `3`(high), `2` (medium), `1` (low)
 
 ###### Default rate limit
 

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1479,6 +1479,7 @@ A geofence represents a custom region or place monitored in your project. Geofen
 - **`userId`** (string): An optional user restriction for the geofence. If set, the geofence will only generate events for the specified user. If not set, the geofence will generate events for all users.
 - **`tripApproachingThreshold`** (number): The [trip approaching threshold](/trip-tracking#trip-events) setting for the geofence. Overrides the project-level trip approaching threshold setting.
 - **`dwellThreshold`** (number): An optional field to trigger dwell events. If set and `user.dwelled_in_geofence` is enabled in settings, an event is triggered when a user dwells in the geofence longer than the threshold (in minutes).
+- **`minimumConfidence`** (number): An optional field to limit events to a defined minimal [geofence confidence](https://radar.com/documentation/geofences#confidence-and-accuracy). Use the following values for the minimum confidence level: `3`(high), `2` (medium), `1` (low).
 - **`enabled`** (boolean): If `true`, the geofence will generate events. If `false`, the geofence will not generate events. Defaults to `true`.
 
 ###### Sample object
@@ -1633,7 +1634,6 @@ Upserts a geofence. The geofence can be uniquely referenced by `tag` and `extern
 - **`mode`** (string, required for type `isochrone`): The [travel mode](/api#routing) for type `isochrone`.
 - **`tripApproachingThreshold`** (number, optional): The [trip approaching threshold](/trip-tracking#trip-events) setting for the geofence. Overrides the project-level trip approaching threshold setting.
 - **`dwellThreshold`** (number, optional): An optional field to trigger dwell events. If set and `user.dwelled_in_geofence` is enabled in settings, an event is triggered when a user dwells in the geofence longer than the threshold (in minutes).
-- **`minimumConfidence`** (number, optional): An optional field to limit events to a defined minimal [geofence confidence](https://radar.com/documentation/geofences#confidence-and-accuracy). Use the following values for the minimum confidence level: `3`(high), `2` (medium), `1` (low)
 
 ###### Default rate limit
 


### PR DESCRIPTION
Include new `geofence.minimalConfidence` parameter to upsert geofence API docs