### PR TITLE
Document debug logging listeners

### DIFF
--- a/docs/sdk/android.mdx
+++ b/docs/sdk/android.mdx
@@ -586,6 +586,11 @@ Your receiver should implement the following:
           // do something with status
       }
 
+      @Override
+      public void onLog(Context context, String message) {
+          // print message for debug logs
+      }
+
   }
   ```
 
@@ -609,6 +614,10 @@ Your receiver should implement the following:
 
       override fun onError(context: Context, status: RadarStatus) {
           // do something with status
+      }
+
+      override fun onLog(context: Context, message: String) {
+          // print message for debug logs
       }
 
   }

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -874,7 +874,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, RadarDelegate {
     // do something with status
 }
 
-- (void)didLog:(NSString *_Nonnull)message {
+- (void)didLogMessage:(NSString *_Nonnull)message {
     // print message for debug logs
 }
 

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -874,7 +874,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, RadarDelegate {
     // do something with status
 }
 
-- (void)didLog:(NSString *)message {
+- (void)didLog:(NSString *_Nonnull)message {
     // print message for debug logs
 }
 

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -835,6 +835,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, RadarDelegate {
         // do something with status
     }
 
+    func didLog(message: String) {
+        // print message for debug logs
+    }
+
 }
 ```
 
@@ -868,6 +872,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, RadarDelegate {
 
 - (void)didFailWithStatus:(RadarStatus)status {
     // do something with status
+}
+
+- (void)didLog:(NSString *)message {
+    // print message for debug logs
 }
 
 @end


### PR DESCRIPTION
follow-up from @palmakkar's onboarding that we don't document the debug log message listeners