### PR TITLE
RN and capacitor foreground service customization

### DIFF
--- a/docs/sdk/capacitor.mdx
+++ b/docs/sdk/capacitor.mdx
@@ -205,6 +205,17 @@ You only need to call these methods once, as these settings will be persisted ac
 Though we recommend using presets for most use cases, you can customize the tracking options. See the [tracking options reference](/sdk/tracking).
 
 ```javascript
+// optionally adjust foreground service options for android
+Radar.setForegroundServiceOptions({
+  options: {
+    text: "Location tracking started",
+    title: "Location updates",
+    updatesOnly: false,
+    importance: 2,
+    activity: 'com.yourapp.MainActivity'
+  }
+});
+
 Radar.startTrackingCustom({
   options: {
     desiredStoppedUpdateInterval: 180,
@@ -215,7 +226,8 @@ Radar.startTrackingCustom({
     stopDistance: 70,
     sync: 'all',
     replay: 'none',
-    showBlueBar: true
+    showBlueBar: true,
+    foregroundServiceEnabled: true
   }
 });
 ```

--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -212,6 +212,17 @@ You only need to call these methods once, as these settings will be persisted ac
 Though we recommend using presets for most use cases, you can customize the tracking options. See the [tracking options reference](/sdk/tracking).
 
 ```javascript
+// optionally adjust foreground service options for android
+Radar.setForegroundServiceOptions({
+  options: {
+    text: "Location tracking started",
+    title: "Location updates",
+    updatesOnly: false,
+    importance: 2,
+    activity: 'com.yourapp.MainActivity'
+  }
+});
+
 Radar.startTrackingCustom({
   desiredStoppedUpdateInterval: 180,
   desiredMovingUpdateInterval: 60,
@@ -221,7 +232,8 @@ Radar.startTrackingCustom({
   stopDistance: 70,
   sync: 'all',
   replay: 'none',
-  showBlueBar: true
+  showBlueBar: true,
+  foregroundServiceEnabled: true
 });
 ```
 


### PR DESCRIPTION
## What?

Improve custom tracking options and include new `setForegroundServiceOptions` function. Right now this is only exposed on Capacitor and React Native. This is a subset of https://github.com/radarlabs/documentation/pull/147

## Why?

Missing