### PR TITLE
Update Algolia API key and App ID

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -55,8 +55,8 @@ module.exports = {
       ],
     },
     algolia: {
-      apiKey: 'c6ef22def89d89fa4c79364b415590aa',
-      appId: 'BH4D9OD16A',
+      apiKey: '604d5f6f90cc8e49f532cd33b4b6c37e',
+      appId: 'HNJN02FL1I',
       indexName: 'radar',
     },
     colorMode: {


### PR DESCRIPTION
## Summary
Updating the Algolia API key and App ID in order to refresh the index.

## QA
Place matching isn't in the current index.  Here is a screenshot w/ the new config and index built on Algolia:

### Before
![image](https://user-images.githubusercontent.com/32653448/197064636-1eb51c33-1f8a-4e82-b4ac-5c07ae31d4a7.png)

### After
![image](https://user-images.githubusercontent.com/32653448/197064528-396e4ffb-99af-4a82-9bd0-3cfea49f4b8a.png)
