### PR TITLE
Remove vercel noindex header

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,11 +5,5 @@
   "redirects": [
     { "source": "/", "destination": "/documentation/", "permanent": true }
   ],
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [{ "key": "X-Robots-Tag", "value": "noindex" }]
-    }
-  ],
   "trailingSlash": false
 }


### PR DESCRIPTION
Now that we're hosting the docs on Vercel, we need to make sure this header is not included in the response.

Preview deployments should already include this header by default: https://vercel.com/guides/are-vercel-preview-deployment-indexed-by-search-engines