### PR TITLE
RAD-5740 cache recent locations in websdk with variable ttl docs

### DIFF
--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -46,7 +46,7 @@ To set options, use:
 ```javascript
 Radar.initialize(publishableKey,
   {
-    locationTimeToLive: 30
+    cacheLocationMinutes: 30
   }
 );
 ```

--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -49,7 +49,6 @@ Radar.initialize(publishableKey,
     timeToLive: 30
   }
 );
-
 ```
 
 ### Identify user

--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -45,11 +45,9 @@ where `publishableKey` is a string containing your Radar publishable API key.
 Optionally, to cache location updates for a period of time and avoid re-prompting for location,
 provide a `cacheLocationMinutes` value as an option when initializing:
 ```javascript
-Radar.initialize(publishableKey,
-  {
-    cacheLocationMinutes: 30
-  }
-);
+Radar.initialize(publishableKey, {
+  cacheLocationMinutes: 30
+});
 ```
 
 ### Identify user

--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -42,7 +42,8 @@ Radar.initialize(publishableKey);
 
 where `publishableKey` is a string containing your Radar publishable API key.
 
-To set options, use:
+Optionally, to cache location updates for a period of time and avoid re-prompting for location,
+provide a `cacheLocationMinutes` value as an option when initializing:
 ```javascript
 Radar.initialize(publishableKey,
   {

--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -42,6 +42,16 @@ Radar.initialize(publishableKey);
 
 where `publishableKey` is a string containing your Radar publishable API key.
 
+To set options, use:
+```javascript
+Radar.initialize(publishableKey,
+  {
+    timeToLive: 30
+  }
+);
+
+```
+
 ### Identify user
 
 To identify the user when logged in, call:

--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -46,7 +46,7 @@ To set options, use:
 ```javascript
 Radar.initialize(publishableKey,
   {
-    timeToLive: 30
+    locationTimeToLive: 30
   }
 );
 ```


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
<!--
  Please explain what problem your pull request is trying to solve.
  Are there any linked issues?
-->
Added a location time to live for `Track.trackOnce()` see: https://github.com/radarlabs/radar-sdk-js/pull/86


## Why?
<!--
  Explain the **motivation** for making this change.
-->
Cache the location so that location request aren't always required when using a browser such as safari which can prompt permissions upon every page reload

## How?
<!--
  If you made a functional change (as opposed to just a content change):
    - How did you implement this change?
    - What decisions did you make?
-->
Pass in optional options in `Radar.initialize()`


## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->
Updated docs:

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/35120291/217070702-ce5f67c4-688a-4da2-b90c-b2ce845981fb.png">
## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
