### PR TITLE
fix foreground service table option

### DIFF
--- a/docs/sdk/tracking.mdx
+++ b/docs/sdk/tracking.mdx
@@ -178,7 +178,7 @@ Option | Efficient | Responsive | Continuous
 **`movingGeofenceRadius`** | `0` | `100` | `0`
 **`syncGeofences`** | `true` | `true` | `false`
 **`syncGeofencesLimit`** | `10` | `10` | `0`
-**`foregroundService`** | `null` | `null` | `null`
+**`foregroundServiceEnabled`** | `false` | `false` | `true`
 **`beacons`** | `false` | `false` | `false`
 
 ## Remote tracking options


### PR DESCRIPTION
## What?

ForegroundService still used as a tracking option for presets

## Why?

Stale tracking option.