### PR TITLE
Remove distance from forward geocode sample response

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -427,7 +427,6 @@ curl "https://api.radar.io/v1/geocode/forward?query=20+jay+st+brooklyn+ny" \
       "countryCode": "US",
       "countryFlag": "🇺🇸",
       "county": "Kings County",
-      "distance": 0,
       "confidence": "exact",
       "borough": "Brooklyn",
       "city": "Brooklyn",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?

Removing distance param from forward geocode sample response in docs


## Why?
Per discussion in slack  https://radarlabs.slack.com/archives/C01EYFCCHBQ/p1677082941325419?thread_ts=1677082265.106759&cid=C01EYFCCHBQ we should not be returning this value in forward geocode 

Related ticket to remove the value in forward geocode responses is here: https://linear.app/radarlabs/issue/INF-555/bug-stop-returning-distance-param-in-forward-geocode-responses
 

## How?
Removed the line that contained the distance param in sample response section of forward geocode docs, no other changes

## Screenshots (optional)
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/33092372/220734746-6f837221-42cb-447a-bc61-cbace5532589.png">

## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
