### PR TITLE
Clarify when to set the Airship channel id

### DIFF
--- a/docs/integrations/urban-airship.mdx
+++ b/docs/integrations/urban-airship.mdx
@@ -30,6 +30,8 @@ Radar.setMetadata([
 ])
 ```
 
+It is recommended to set the Radar user metadata once the Airship channel ID becomes available. This can be performed via the `addChannelListener` [Airship methods](https://docs.airship.com/platform/mobile/audience/#accessing-the-airship-channel-id).
+
 ## User mapping
 
 Radar User Field | Airship Tag Group Name | Type | Example Tag | Context Type


### PR DESCRIPTION
## What?

Instructions to use the Airship channel listener as the channel id can be null

## Why?

Important to maximize audience size between Radar and Airship.