### PR TITLE
Fix receiver implementation for new signature

### DIFF
--- a/docs/sdk/android.mdx
+++ b/docs/sdk/android.mdx
@@ -658,7 +658,7 @@ To listen for events, location updates, and errors client-side, create a class t
           super.onCreate();
 
           MyRadarReceiver receiver = new MyRadarReceiver();
-          Radar.initialize(this, "prj_test_pk...", receiver);
+          Radar.initialize(this, "prj_test_pk...", receiver, Radar.RadarLocationServicesProvider.GOOGLE);
       }
 
   }

--- a/docs/sdk/android.mdx
+++ b/docs/sdk/android.mdx
@@ -676,7 +676,7 @@ To listen for events, location updates, and errors client-side, create a class t
           super.onCreate()
 
           val receiver = MyRadarReceiver()
-          Radar.initialize(this, "prj_test_pk...", receiver)
+          Radar.initialize(this, "prj_test_pk...", receiver, Radar.RadarLocationServicesProvider.GOOGLE)
       }
 
   }


### PR DESCRIPTION
## What?

Update our java receiver implementation code.

## Why?
Requires the location provider to be declared since we introduced HMS support.