### PR TITLE
React Native bg location permissions explanation + 3.5.7 ref fix for trip options

### DIFF
--- a/docs/sdk/react-native-3.5.7.mdx
+++ b/docs/sdk/react-native-3.5.7.mdx
@@ -2,8 +2,8 @@
 sidebar_position: 4
 sidebar_label: React Native
 title: React Native SDK
-id: react-native-3.5.1
-description: Documentation for React Native SDK 3.5.1 and Below
+id: react-native-3.5.7
+description: Documentation for React Native SDK 3.5.7 and Below
 ---
 
 import Alert from "../../src/components/Alert";

--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -81,6 +81,16 @@ public class MainApplication extends Application implements ReactApplication {
 }
 ```
 
+For background tracking without a foreground service, and if targeting API level `29` or higher, Radar also requires the `ACCESS_BACKGROUND_LOCATION` permission. You must add the `ACCESS_BACKGROUND_LOCATION` permission to your manifest manually:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
+</manifest>
+```
+
 ## Integrate
 
 ### Import module
@@ -300,7 +310,7 @@ On Android, a receiver in the React Native module loads and parses the JavaScrip
 ### Trip tracking
 
 <Alert alertType="info">
-  See trip tracking docs for React Native SDK versions older than v3.5.8 <a href="/sdk/react-native-3.5.1#trip-tracking">here</a>.
+  See trip tracking docs for React Native SDK versions v3.5.7 and below <a href="/sdk/react-native-3.5.7#trip-tracking">here</a>.
 </Alert>
 
 To start a trip to a destination, call:


### PR DESCRIPTION
Fixes CORE-330

## What?

Bad link to old trip tracking functions + adds missing explanation of manifest requirement.

## Why?

Missing + incorrect docs.
