### PR TITLE
Remove team tier references

### DIFF
--- a/docs/integrations/amplitude.mdx
+++ b/docs/integrations/amplitude.mdx
@@ -4,11 +4,10 @@ title: Amplitude
 import Alert from "../../src/components/Alert";
 
 <Alert alertType="info">
-  The Amplitude integration is available on the {` `} 
-  <a href="https://radar.com/pricing" target="_blank">Team plan</a>
-  {` `} and higher.
+  The Amplitude integration is available on the {` `}
+  <a href="https://radar.com/pricing" target="_blank">Enterprise plan</a>
+  .
 </Alert>
-
 Radar can send events and user properties to [Amplitude](https://amplitude.com).
 
 Use the Amplitude integration to enrich behavioral events with location context, measure the ROI of location-based features, and build location-based user segments.

--- a/docs/integrations/branch.mdx
+++ b/docs/integrations/branch.mdx
@@ -5,10 +5,9 @@ import Alert from "../../src/components/Alert";
 
 <Alert alertType="info">
   The Branch integration is available on the {` `}
-  <a href="https://radar.com/pricing" target="_blank">Team plan</a>
-  {` `} and higher.
+  <a href="https://radar.com/pricing" target="_blank">Enterprise plan</a>
+  .
 </Alert>
-
 Radar can send events to [Branch](https://branch.io).
 
 Use the Branch integration to attribute offline actions to online campaigns and measure the ROI of location-based features.

--- a/docs/integrations/mixpanel.mdx
+++ b/docs/integrations/mixpanel.mdx
@@ -4,11 +4,10 @@ title: Mixpanel
 import Alert from "../../src/components/Alert";
 
 <Alert alertType="info">
-  The Mixpanel integration is available on the {` `} 
-  <a href="https://radar.com/pricing" target="_blank">Team plan</a>
-  {` `} and higher.
+  The Mixpanel integration is available on the {` `}
+  <a href="https://radar.com/pricing" target="_blank">Enterprise plan</a>
+  .
 </Alert>
-
 Radar can send events and user properties to [Mixpanel](https://www.mixpanel.com).
 
 Use the Mixpanel integration to enrich behavioral events with location context, measure the ROI of location-based features, and build location-based user segments.

--- a/docs/integrations/onesignal.mdx
+++ b/docs/integrations/onesignal.mdx
@@ -5,10 +5,9 @@ import Alert from "../../src/components/Alert";
 
 <Alert alertType="info">
   The OneSignal integration is available on the {` `}
-  <a href="https://radar.com/pricing" target="_blank">Team plan</a>
-  {` `} and higher.
+  <a href="https://radar.com/pricing" target="_blank">Enterprise plan</a>
+  .
 </Alert>
-
 Radar can send tags to and trigger notifications in [OneSignal](https://onesignal.com). You can create notifications triggered by tag changes.
 
 Use the OneSignal integration to send location-triggered and location-targeted messages to increase engagement and conversion.

--- a/docs/integrations/segment.mdx
+++ b/docs/integrations/segment.mdx
@@ -4,11 +4,10 @@ title: Segment
 import Alert from "../../src/components/Alert";
 
 <Alert alertType="info">
-  The Segment integration is available on the {` `} 
-  <a href="https://radar.com/pricing" target="_blank">Team plan</a>
-  {` `} and higher.
+  The Segment integration is available on the {` `}
+  <a href="https://radar.com/pricing" target="_blank">Enterprise plan</a>
+  .
 </Alert>
-
 Radar can send events and user traits to [Segment](https://segment.com) as a source. Segment can send those events and user traits to your warehouse and to hundreds of destinations.
 
 Use the Segment integration to forward location events and user context to any destinations or to build location-based user segments with Personas.

--- a/docs/integrations/urban-airship.mdx
+++ b/docs/integrations/urban-airship.mdx
@@ -2,7 +2,6 @@
 title: Airship
 ---
 import Alert from "../../src/components/Alert";
-
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import InlineTabs from "../../src/components/InlineTabs";
@@ -12,8 +11,8 @@ import DefaultContextValues from "../../src/components/DefaultContextValues";
 
 <Alert alertType="info">
   The Airship integration is available on the {` `}
-  <a href="https://radar.com/pricing" target="_blank">Team plan</a>
-  {` `} and higher.
+  <a href="https://radar.com/pricing" target="_blank">Enterprise plan</a>
+  .
 </Alert>
 
 <DefaultContextValues/>


### PR DESCRIPTION
## What?

Remove team tier references in integrations

## Why?

Non supported plan.
