### PR TITLE
Units is an optional input in routing endpoints

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -907,7 +907,7 @@ Calculates the travel distance and duration between an origin and a destination.
 - **`origin`** (string, required): The origin. A string in the format `latitude,longitude`.
 - **`destination`** (string, required): The destination. A string in the format `latitude,longitude`.
 - **`modes`** (string, required): The [travel modes](/api#route-distance). A string, comma-separated, including one or more of `foot`, `bike`, and `car`.
-- **`units`** (string, required): The distance units. A string, `metric` or `imperial`.
+- **`units`** (string, optional): The distance units. A string, `metric` or `imperial`. Defaults to `imperial` if not provided.
 
 ###### Authentication level
 
@@ -975,7 +975,7 @@ Calculates the travel distances and durations between multiple origins and desti
 - **`origins`** (string, required): A list of origins. A pipe-delimited string in the format `latitude0,longitude0|latitude1,longitude1|...`.
 - **`destinations`** (string, required): A list of destinations. A pipe-delimited string in the format `latitude0,longitude0|latitude1,longitude1|...`.
 - **`mode`** (string, required): The travel mode. A string, one of `foot`, `bike`, or `car`.
-- **`units`** (string, required): The distance units. A string, `metric` or `imperial`.
+- **`units`** (string, optional): The distance units. A string, `metric` or `imperial`. Defaults to `imperial` if not provided.
 
 ###### Authentication level
 


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
<!--
  Please explain what problem your pull request is trying to solve.
  Are there any linked issues?
-->

We don't actually enforce that units is a required input, we accept calls without and default to imperial if not provided. 

We should either deploy this change to ensure docs are accurate, or actually start enforcing units as a required input param.

## Why?
<!--
  Explain the **motivation** for making this change.
-->

Ensuring our docs match actual behavior

## How?
<!--
  If you made a functional change (as opposed to just a content change):
    - How did you implement this change?
    - What decisions did you make?
-->

## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->

## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
