### PR TITLE
Rename `sendEvent` to `logConversion` in kotlin snippet in conversions tutorial

### DIFF
--- a/docs/tutorials/logging-and-analyzing-where-conversions-occur.md
+++ b/docs/tutorials/logging-and-analyzing-where-conversions-occur.md
@@ -124,7 +124,7 @@ Radar.logConversion(
 ```kotlin
 // on searching for a product
 val metadata = JSONObject(mapOf("product" to "shirt"))
-Radar.sendEvent(
+Radar.logConversion(
     "purchase",
     12.50,
     metadata


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
<!--
  Please explain what problem your pull request is trying to solve.
  Are there any linked issues?
-->
The kotlin snippet in the conversions tutorial uses `sendEvent` instead of `logConversion`

## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->
#### Before
<img width="999" alt="Screenshot 2023-04-26 at 11 43 23 AM" src="https://user-images.githubusercontent.com/122315545/234629374-a0897f1e-e44c-40c1-adf6-424b632aa74f.png">


#### After

<img width="999" alt="Screenshot 2023-04-26 at 11 42 14 AM" src="https://user-images.githubusercontent.com/122315545/234629152-4deac614-a180-4691-a423-dbaa219d79c9.png">
