### PR TITLE
use default map style

### DIFF
--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -87,7 +87,7 @@ class RadarMap extends React.Component {
   componentDidMount() {
     const map = new maplibregl.Map({
       container: 'map',
-      style: `https://api.radar.io/maps/styles/radar-streets-beta?publishableKey=${PUBLISHABLE_KEY}`,
+      style: `https://api.radar.io/maps/styles/radar-default-v1?publishableKey=${PUBLISHABLE_KEY}`,
       center: [-73.9911, 40.7342], // NYC
       zoom: 11
     });

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -8,7 +8,7 @@ class Map extends React.Component {
   componentDidMount() {
     const map = new maplibregl.Map({
       container: CONTAINER,
-      style: `https://api.radar.io/maps/styles/radar-streets-beta?publishableKey=${PUBLISHABLE_KEY}`,
+      style: `https://api.radar.io/maps/styles/radar-default-v1?publishableKey=${PUBLISHABLE_KEY}`,
       center: [-73.9911, 40.7342], // NYC
       zoom: 11
     });


### PR DESCRIPTION
Use the default Radar maps style: `radar-default-v1`

<img width="1261" alt="image" src="https://github.com/radarlabs/documentation/assets/814934/9ececc8c-b528-4aff-8016-5e6dba8b1001">
