### PR TITLE
FENCE-947 Add region id to amplitude integration

### DIFF
--- a/docs/integrations/amplitude.mdx
+++ b/docs/integrations/amplitude.mdx
@@ -49,11 +49,15 @@ Radar User Field | Amplitude User Property | Type | Example Value | Context Type
 `place.chain.name` | `[Radar] Place Chain Name` | string | `"Starbucks"` | [Places](/places)
 `country.code` | `[Radar] Region Country Code` | string | `"US"` | [Regions](/regions)
 `country.name` | `[Radar] Region Country Name` | string | `"United States"` | [Regions](/regions)
+`country._id` | `[Radar] Region Country ID` | string | `"5b2c0906f5874b001aecfd8f"` | [Regions](/regions)
 `state.code` | `[Radar] Region State Code` | string | `"MD"` | [Regions](/regions)
 `state.name` | `[Radar] Region State Name` | string | `"Maryland"` | [Regions](/regions)
+`state._id` | `[Radar] Region State ID` | string | `"5b2c0906f5874b001aecfd8f"` | [Regions](/regions)
 `dma.code` | `[Radar] Region DMA Code` | string | `"26"` | [Regions](/regions)
 `dma.name` | `[Radar] Region DMA Name` | string | `"Baltimore"` | [Regions](/regions)
+`dma._id` | `[Radar] Region DMA ID` | string | `"5b2c0906f5874b001aecfd8f"` | [Regions](/regions)
 `postalCode.code` | `[Radar] Region Postal Code` | string | `"21014"` | [Regions](/regions)
+`postalCode._id` | `[Radar] Region Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"` | [Regions](/regions)
 `trip.externalId` | `[Radar] Trip External ID` | string | `"299"` | [Trip Tracking](/trip-tracking)
 `trip.destinationGeofenceTag` | `[Radar] Trip Destination Geofence Tag` | string | `"store"` | [Trip Tracking](/trip-tracking)
 `trip.destinationGeofenceExternalId` | `[Radar] Trip Destination Geofence External ID` | string | `"123"` | [Trip Tracking](/trip-tracking)
@@ -104,11 +108,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Geofence Exited
 
@@ -130,11 +138,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Dwelled in Geofence
 
@@ -156,11 +168,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Place Entered
 
@@ -181,11 +197,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Place Exited
 
@@ -207,11 +227,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Country Entered
 
@@ -229,11 +253,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Country Exited
 
@@ -251,11 +279,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; State Entered
 
@@ -273,11 +305,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; State Exited
 
@@ -295,11 +331,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; DMA Entered
 
@@ -317,11 +357,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; DMA Exited
 
@@ -339,11 +383,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Started Trip
 
@@ -362,11 +410,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Updated Trip
 
@@ -385,11 +437,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Approaching Trip Destination
 
@@ -408,11 +464,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Arrived at Trip Destination
 
@@ -431,11 +491,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Stopped Trip
 
@@ -454,11 +518,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Beacon Entered
 
@@ -477,11 +545,15 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`
 
 ### &lbrack;Radar&rbrack; Beacon Exited
 
@@ -501,8 +573,12 @@ Radar Event Field | Amplitude Event Property | Type | Example Value
 --- | --- | --- | ---
 `country.code` | `Country Code` | string | `"US"`
 `country.name` | `Country Name` | string | `"United States"`
+`country._id` | `Country ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `state.code` | `State Code` | string | `"MD"`
 `state.name` | `State Name` | string | `"Maryland"`
+`state._id` | `State ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `dma.code` | `DMA Code` | string | `"26"`
 `dma.name` | `DMA Name` | string | `"Baltimore"`
+`dma._id` | `DMA ID` | string | `"5b2c0906f5874b001aecfd8f"`
 `postalCode.code` | `Postal Code` | string | `"21014"`
+`postalCode._id` | `Postal Code ID` | string | `"5b2c0906f5874b001aecfd8f"`


### PR DESCRIPTION
Pending the merge of https://github.com/radarlabs/server/pull/4917

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
<!--
  Please explain what problem your pull request is trying to solve.
  Are there any linked issues?
-->

As part of coarse insights, we want region IDs to be populated down to the amplitude integration. This is so that Traveloka can map our IDs to their internal region IDs.

## Why?
<!--
  Explain the **motivation** for making this change.
-->

## How?
<!--
  If you made a functional change (as opposed to just a content change):
    - How did you implement this change?
    - What decisions did you make?
-->

## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->

## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
