### PR TITLE
document "near" and "input" params for autocomplete

### DIFF
--- a/docs/maps/autocomplete.mdx
+++ b/docs/maps/autocomplete.mdx
@@ -11,6 +11,33 @@ Add an address autocomplete widget to your site with just a few lines of code.
 
 To use the Radar Autocomplete input, simply initialize the Radar SDK with your publishable key, and specify the container to render the input into.
 
+## Configuration
+
+When creating the Autocomplete input, you can provide options to customize the autocomplete behavior, as well as the size of the input.
+
+<div class="full-width-table">
+
+| Name  | Default | Possible Values | Description           | SDK availability |
+|-------|---------|-----------------|-----------------------|------------------|
+|`container` |`autocomplete` |string \| HTMLElement |The container the autocomplete input will be rendered into. Can specify the html `id`, or DOM object. <br /><br /><b>Note:</b> If an `<input>` is provided as the container, the `<input>`'s style will not be modified. |Web|
+|`width` |`400` |number \| string |Width of the input. Can be a number (in pixels) or a valid CSS width.|Web|
+|`near` |`null` |string \| Location | The location to search. If not provided, the request IP address will be used to anchor the search. <br /><br />Can be provided as a string in the format `latitude,longitude` or as an object `{ latitude, longitude }`. |Web, React Native|
+|`debounceMS` |`200` |number |The number of milliseconds to wait after typing is complete to refresh the result list.|Web, React Native|
+|`threshold` |`3` |number |Minimum number of characters that need to be typed before fetching results.|Web, React Native|
+|`limit` |`8` |number |Maximum number of results to show.|Web, React Native|
+|`onSelection` |`null` |function `(address) => {}`|Callback with selected address.|Web, React Native|
+|`onResults` |`null` |function `(addresses) => {}`|Callback with list of address results.|Web, React Native|
+|`onError` |`null` |function `(error) => {}`|Callback with any errors that occur.|Web, React Native|
+|`placeholder` |`Search address` |string |Input placeholder text|Web, React Native|
+|`responsive` |`true` |boolean |Whether the input should expand to fill the parent container or not. If `responsive` is true _and_ a `width` is provided, `width` will be treated as a "max-width".|Web|
+|`disabled` |`false` |boolean |Disables the input.|Web, React Native|
+|`layers` |`null` |`place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, `fine` |Filter results by layer type. See [Autocomplete docs](/documentation/api#query-parameters-3) for more info.|Web, React Native|
+|`countryCode` |`null` |string|2-letter country code to filter results by.|Web, React Native|
+|`showMarkers` |`true` |boolean |Show map pin icons next to results in the list.|Web, React Native|
+|`markerColor` |`#ACBDC8` |string |CSS color for marker icon.|Web|
+|`style`|`null`|React Native style object|Styles for the element. See the [code](https://github.com/radarlabs/react-native-radar/blob/be23434ba731dda7015e25b7fc3a6364ff1b311d/js/ui/autocomplete.jsx#L153) for specifics.|React Native|
+</div>
+
 ## Quickstart
 
 First, [sign up](https://radar.com/signup) for Radar and get an API key.
@@ -76,29 +103,3 @@ export default function App() {
 }
 ```
 
-## Configuration
-
-When creating the Autocomplete input, you can provide options to customize the autocomplete behavior, as well as the size of the input.
-
-<div class="full-width-table">
-
-| Name  | Default | Possible Values | Description           | SDK availability |
-|-------|---------|-----------------|-----------------------|------------------|
-|`container` |`autocomplete` |string \| HTMLElement |The container the autocomplete input will be rendered into. Can specify the html `id`, or DOM object. <br /><br /><b>Note:</b> If an `<input>` is provided as the container, styling will be controlled by the user. |Web|
-|`width` |`400` |number \| string |Width of the input. Can be a number (in pixels) or a valid CSS width.|Web|
-|`near` |`null` |string \| Location | The location to search. If not provided, the request IP address will be used to anchor the search. <br /><br />Can be provided as a string in the format `latitude,longitude` or as an object `{ latitude, longitude }`. |Web, React Native|
-|`debounceMS` |`200` |number |The number of milliseconds to wait after typing is complete to refresh the result list.|Web, React Native|
-|`threshold` |`3` |number |Minimum number of characters that need to be typed before fetching results.|Web, React Native|
-|`limit` |`8` |number |Maximum number of results to show.|Web, React Native|
-|`onSelection` |`null` |function `(address) => {}`|Callback with selected address.|Web, React Native|
-|`onResults` |`null` |function `(addresses) => {}`|Callback with list of address results.|Web, React Native|
-|`onError` |`null` |function `(error) => {}`|Callback with any errors that occur.|Web, React Native|
-|`placeholder` |`Search address` |string |Input placeholder text|Web, React Native|
-|`responsive` |`true` |boolean |Whether the input should expand to fill the parent container or not. If `responsive` is true _and_ a `width` is provided, `width` will be treated as a "max-width".|Web|
-|`disabled` |`false` |boolean |Disables the input.|Web, React Native|
-|`layers` |`null` |`place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, `fine` |Filter results by layer type. See [Autocomplete docs](/documentation/api#query-parameters-3) for more info.|Web, React Native|
-|`countryCode` |`null` |string|2-letter country code to filter results by.|Web, React Native|
-|`showMarkers` |`true` |boolean |Show map pin icons next to results in the list.|Web, React Native|
-|`markerColor` |`#ACBDC8` |string |CSS color for marker icon.|Web|
-|`style`|`null`|React Native style object|Styles for the element. See the [code](https://github.com/radarlabs/react-native-radar/blob/be23434ba731dda7015e25b7fc3a6364ff1b311d/js/ui/autocomplete.jsx#L153) for specifics.|React Native|
-</div>

--- a/docs/maps/autocomplete.mdx
+++ b/docs/maps/autocomplete.mdx
@@ -84,21 +84,21 @@ When creating the Autocomplete input, you can provide options to customize the a
 
 | Name  | Default | Possible Values | Description           | SDK availability |
 |-------|---------|-----------------|-----------------------|------------------|
-|`container` |`autocomplete` |string \| HTMLElement |The container the autocomplete input will be rendered into. Can specify the html `id`, or DOM object.|JavaScript|
-|`width` |`400` |number \| string |Width of the input. Can be a number (in pixels) or a valid CSS width.|JavaScript|
-|`debounceMS` |`200` |number |The number of milliseconds to wait after typing is complete to refresh the result list.|JavaScript, React Native|
-|`threshold` |`3` |number |Minimum number of characters that need to be typed before fetching results.|JavaScript, React Native|
-|`near`|`null`|location object|Location used to bias results. Falls back to IP location if nothing is supplied.|React Native|
-|`limit` |`8` |number |Maximum number of results to show.|JavaScript, React Native|
-|`onSelection` |`null` |function `(address) => {}`|Callback with selected address.|JavaScript, React Native|
-|`onResults` |`null` |function `(addresses) => {}`|Callback with list of address results.|JavaScript, React Native|
-|`onError` |`null` |function `(error) => {}`|Callback with any errors that occur.|JavaScript, React Native|
-|`placeholder` |`Search address` |string |Input placeholder text|JavaScript, React Native|
-|`responsive` |`true` |boolean |Whether the input should expand to fill the parent container or not. If `responsive` is true _and_ a `width` is provided, `width` will be treated as a "max-width".|JavaScript|
-|`disabled` |`false` |boolean |Disables the input.|JavaScript, React Native|
-|`layers` |`null` |`place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, `fine` |Filter results by layer type. See [Autocomplete docs](/documentation/api#query-parameters-3) for more info.|JavaScript, React Native|
-|`countryCode` |`null` |string|2-letter country code to filter results by.|JavaScript, React Native|
-|`showMarkers` |`true` |boolean |Show map pin icons next to results in the list.|JavaScript, React Native|
-|`markerColor` |`#ACBDC8` |string |CSS color for marker icon.|JavaScript|
+|`container` |`autocomplete` |string \| HTMLElement |The container the autocomplete input will be rendered into. Can specify the html `id`, or DOM object. <br /><br /><b>Note:</b> If an `<input>` is provided as the container, styling will be controlled by the user. |Web|
+|`width` |`400` |number \| string |Width of the input. Can be a number (in pixels) or a valid CSS width.|Web|
+|`near` |`null` |string \| Location | The location to search. If not provided, the request IP address will be used to anchor the search. <br /><br />Can be provided as a string in the format `latitude,longitude` or as an object `{ latitude, longitude }`. |Web, React Native|
+|`debounceMS` |`200` |number |The number of milliseconds to wait after typing is complete to refresh the result list.|Web, React Native|
+|`threshold` |`3` |number |Minimum number of characters that need to be typed before fetching results.|Web, React Native|
+|`limit` |`8` |number |Maximum number of results to show.|Web, React Native|
+|`onSelection` |`null` |function `(address) => {}`|Callback with selected address.|Web, React Native|
+|`onResults` |`null` |function `(addresses) => {}`|Callback with list of address results.|Web, React Native|
+|`onError` |`null` |function `(error) => {}`|Callback with any errors that occur.|Web, React Native|
+|`placeholder` |`Search address` |string |Input placeholder text|Web, React Native|
+|`responsive` |`true` |boolean |Whether the input should expand to fill the parent container or not. If `responsive` is true _and_ a `width` is provided, `width` will be treated as a "max-width".|Web|
+|`disabled` |`false` |boolean |Disables the input.|Web, React Native|
+|`layers` |`null` |`place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, `fine` |Filter results by layer type. See [Autocomplete docs](/documentation/api#query-parameters-3) for more info.|Web, React Native|
+|`countryCode` |`null` |string|2-letter country code to filter results by.|Web, React Native|
+|`showMarkers` |`true` |boolean |Show map pin icons next to results in the list.|Web, React Native|
+|`markerColor` |`#ACBDC8` |string |CSS color for marker icon.|Web|
 |`style`|`null`|React Native style object|Styles for the element. See the [code](https://github.com/radarlabs/react-native-radar/blob/be23434ba731dda7015e25b7fc3a6364ff1b311d/js/ui/autocomplete.jsx#L153) for specifics.|React Native|
 </div>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,7 +89,7 @@ module.exports = {
   ],
   scripts: [
     {
-      src: 'js/fullstory.js',
+      src: '/documentation/js/fullstory.js',
       async: true,
     }
   ]


### PR DESCRIPTION
* Add `near` param for Web autocomplete
* Document behavior when using `<input>` for autocomplete container