### PR TITLE
home and traveling detection

### DIFF
--- a/docs/regions.mdx
+++ b/docs/regions.mdx
@@ -79,48 +79,41 @@ Regions supports DMA (designated market area) detection in the US only. Each DMA
 
 Regions supports postal (ZIP) code detection in the US only. Each postal code has a unique 5-letter `code`.
 
-## Coarse insights
+## Coarse home and traveling detection
 
-With Coarse Insights, you can determine a user's home regions and detect traveling globally. To enable, contact your customer success manager.
+<Alert alertType="info">
+  Contact your customer success manager for access to coarse home and traveling detection.
+</Alert>
 
-Coarse Insights provides the following user context:
+Regions can automatically detect a user's home regions based on location updates in the last 30 days, and detect when a user is traveling outside of their home regions.
+
+Coarse home detection provides the following user context:
 
 ```json
 {
   "homeRegions": {
     "country": {
-      "_id":  "5cf694f66da6a800683f4d71",
-      "type": "country",
-      "name": "United States",
       "code": "US",
-      "icon": "🇺🇸",
+      "name": "United States",
+      "flag": "🇺🇸"
     },
     "state": {
-      "_id":  "5cf695086da6a800683f4e69",
-      "type": "state",
-      "name": "Maryland",
       "code": "MD",
-      "icon": "🇺🇸",
+      "name": "Maryland"
     },
     "dma": {
-      "_id":  "5cf694fb6da6a800683f4d92",
-      "type": "dma",
-      "name": "Baltimore",
       "code": "26",
-      "icon": "🇺🇸",
-    }
+      "name": "Baltimore"
+    },
     "postalCode": {
-      "_id":  "5cf6955c6da6a800683f6753",
-      "type": "postalCode",
-      "name": "21014",
-      "code": "21014",
-      "icon": "🇺🇸",
+      "code": "21014"
     }
   }
 }
 ```
 
-It also provides the following event context:
+It also provides the following `traveling` state on events:
+
 ```json
 {
   "traveling": {
@@ -131,12 +124,3 @@ It also provides the following event context:
   }
 }
 ```
-
-### How it works
-
-Upon the first track call of the day, the regions calculated for a given user are stored in a recency list. A user's home regions are determined by calculating the most frequently occurring regions from this list, storing up to the past 30 days in which a track call was made.
-If the most recent entry is different from the user's home regions, the user is determined to be traveling and the event context is updated accordingly.
-
-
-
-


### PR DESCRIPTION
- simplify docs
- use info bubble for CSM access
- strip extraneous fields out of sample response (to match sample response at the top of the page)