### PR TITLE
remove coordinates from airship integration

### DIFF
--- a/docs/integrations/urban-airship.mdx
+++ b/docs/integrations/urban-airship.mdx
@@ -170,8 +170,6 @@ class MyRadarReceiver: RadarReceiver() {
 
 Radar User Field | Airship Tag Group Name | Type | Example Tag | Context Type
 --- | --- | --- | --- | ---
-`location.coordinates[0]` | `radar_location_longitude` | number | `-76.350663` |
-`location.coordinates[1]` | `radar_location_latitude` | number | `39.525665` |
 `locationAuthorization` | `radar_location_authorization` | string | `"GRANTED_FOREGROUND"` |
 `locationAccuracyAuthorization` | `radar_location_accuracy_authorization` | string | `"FULL"` |
 `updatedAt` | `radar_updated_at` | timestamp | `"2018-06-22T15:23:39.000Z"` |


### PR DESCRIPTION
## What?

Associated with FENCE-1163 - airship tag removal for coordinates

## Why?

Can't be used in Airship integration, so removing from payloads sent (would need to sent as new user attributes feature)
