### PR TITLE
Initial Commit

### DIFF
--- a/docs/geofencing/testing.mdx
+++ b/docs/geofencing/testing.mdx
@@ -80,3 +80,32 @@ The Radar [iOS](/sdk/ios) and [Android](/sdk/android) SDKs automatically generat
 ### Rate limit errors are occurring when tracking location
 
 Radar has device specific rate limits per second, hour and day for the [track API endpoint](/api#track), which sends location updates to Radar. To mitigate rate limits, adjust [tracking options](/sdk/tracking) to collect locations less frequently. If you hit the per hour or day limits while testing, reinstalling the application with the Radar SDK will reset the rate limits.
+
+When a rate limit is triggered, Radar will return three response headers for the request inline with the IETF Rate Limiting Standardization Draft:
+
+###### Response codes
+
+- **`x-ratelimit-limit`**: Maximum amount of request allowed in the current window.
+- **`x-ratelimit-remaining`**: Remaining requests available in the current window before being rate limited.
+- **`x-ratelimit-reset`**: A UNIX timestamp for when the rate limit ends.
+
+###### Sample error response
+
+```json
+{
+    "Date": "Thu, 10 Aug 2023 18:39:34 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "X-Powered-By": "Express",
+    "Access-Control-Allow-Origin": "*",
+    "X-RateLimit-Limit": "1500",
+    "X-RateLimit-Remaining": "1499",
+    "X-RateLimit-Reset": "1691692776",
+    "ETag": "---",
+    "Content-Encoding": "gzip",
+    "CF-Cache-Status": "DYNAMIC",
+    "Server": "cloudflare",
+    "CF-RAY": "---"
+}
+```


### PR DESCRIPTION
@jsani-radar - I see we use Express to handle our rate limits so it should be standard across all our API's but I did notice that:
1) /track always returns these headers while other API's don't
2) Whe diagnosing issues for GPI on beacons we were also receiving a `type` field [sec, min, hr, day]. I think our server appends extra rate limit info but unsure how much we want to potentially include here.