### PR TITLE
Support robots tag

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -56,6 +56,7 @@
     "radarlabs",
     "sfmc",
     "signup",
+    "sportsbook",
     "timewanted",
     "upsert",
     "upserted",

--- a/docs/fraud.mdx
+++ b/docs/fraud.mdx
@@ -182,7 +182,7 @@ Learn more about [Network Security Configuration on Android](https://developer.a
 
 #### App Attest
 
-To support the `compromised` flag on iOS, enable [App Attest](https://developer.apple.com/documentation/devicecheck/preparing_to_use_the_app_attest_service) and configure a list of valid App IDs (e.g., `A1B2C3D4E5.com.yourapp.app1,A1B2C3D4E5.com.yourapp.app2`) on the [Settings page](https://radar.com/dashboard/settings).
+To support the `compromised` flag on iOS, enable [App Attest](https://developer.apple.com/documentation/devicecheck/preparing_to_use_the_app_attest_service) and configure a list of valid [App IDs](https://developer.apple.com/library/archive/documentation/General/Conceptual/DevPedia-CocoaCore/AppID.html) (e.g., `A1B2C3D4E5.com.yourapp.app1,A1B2C3D4E5.com.yourapp.app2`) on the [Settings page](https://radar.com/dashboard/settings).
 
 If App Attest indicates that the user's device or app has been compromised, `user.fraud.compromised = true`.
 

--- a/src/components/radarSeo.jsx
+++ b/src/components/radarSeo.jsx
@@ -72,7 +72,8 @@ const RadarSEO = ({
   _description,
   keywords,
   image,
-  slug
+  slug,
+  robots,
 }) => {
   const {image: defaultImage} = useThemeConfig();
   const pageImage = useBaseUrl(image || defaultImage, {absolute: true});
@@ -102,6 +103,10 @@ const RadarSEO = ({
           name="keywords"
           content={Array.isArray(keywords) ? keywords.join(',') : keywords}
         />
+      )}
+
+      {robots && (
+        <meta name="robots" content={robots} />
       )}
 
       {pageImage && <meta property="og:image" content={pageImage} />}

--- a/src/components/radarSeo.jsx
+++ b/src/components/radarSeo.jsx
@@ -8,6 +8,10 @@ const ROOT_BREADCRUMB = {
   path: '/',
 };
 
+const SLUGS_ROBOTS = {
+  '/regions/countries': 'noindex',
+};
+
 // String Utils
 export const capitalizeFirst = (string = '') => (
   (string[0] || '').toUpperCase() + string.slice(1)
@@ -73,7 +77,6 @@ const RadarSEO = ({
   keywords,
   image,
   slug,
-  robots,
 }) => {
   const {image: defaultImage} = useThemeConfig();
   const pageImage = useBaseUrl(image || defaultImage, {absolute: true});
@@ -90,6 +93,8 @@ const RadarSEO = ({
       pageTitle = `Documentation - ${title} | Radar`;
     }
   }
+
+  const robots = SLUGS_ROBOTS[slug];
 
   return (
     <Head>

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -26,10 +26,12 @@
    const {
      image,
      keywords,
+     customFields,
      hide_title: hideTitle,
      hide_table_of_contents: hideTableOfContents,
    } = frontMatter;
    const { description, title, slug } = metadata;
+   const { robots } = (customFields || {});
 
    // We only add a title if:
    // - user asks to hide it with frontmatter
@@ -54,6 +56,7 @@
           description,
           keywords,
           image,
+          robots,
         }}
       />
 

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -26,7 +26,6 @@
    const {
      image,
      keywords,
-     robots,
      hide_title: hideTitle,
      hide_table_of_contents: hideTableOfContents,
    } = frontMatter;
@@ -55,7 +54,6 @@
           description,
           keywords,
           image,
-          robots,
         }}
       />
 

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -26,12 +26,11 @@
    const {
      image,
      keywords,
-     customFields,
+     robots,
      hide_title: hideTitle,
      hide_table_of_contents: hideTableOfContents,
    } = frontMatter;
    const { description, title, slug } = metadata;
-   const { robots } = (customFields || {});
 
    // We only add a title if:
    // - user asks to hide it with frontmatter


### PR DESCRIPTION
- Support setting `robots` `meta` tag per `slug`, add `noindex` for `/regions/countries` per marketing team feedback (this page is driving a ton of bad traffic from people looking for country emojis)
- Adds link to Apple App ID docs per @lmeier feedback