### PR TITLE
Maps, autocomplete, and web SDK docs edits

### DIFF
--- a/docs/maps/autocomplete.mdx
+++ b/docs/maps/autocomplete.mdx
@@ -7,6 +7,8 @@ Use Radar's autocomplete component to add address autocomplete to your websites 
 
 <AutocompleteInput />
 
+You can also check out the [autocomplete explorer](https://radar.com/dashboard/maps/maps-explorer/autocomplete) in the dashboard, or check out a full-page [maps demo](https://radar.com/demo/maps) and [store locator demo](https://radar.com/demo/locator) with an autocomplete component.
+
 ## How it works
 
 To use the autocomplete component, simply initialize the Radar SDK with your publishable key and specify the container to render the input into.

--- a/docs/maps/autocomplete.mdx
+++ b/docs/maps/autocomplete.mdx
@@ -13,7 +13,7 @@ To use the autocomplete component, simply initialize the Radar SDK with your pub
 
 ## Configuration
 
-When creating the Autocomplete input, you can provide options to customize the autocomplete behavior, as well as the size of the input.
+When creating the autocomplete input, you can provide options to customize the autocomplete behavior, as well as the size of the input.
 
 Available options include:
 

--- a/docs/maps/autocomplete.mdx
+++ b/docs/maps/autocomplete.mdx
@@ -3,13 +3,13 @@ title: Autocomplete
 ---
 import AutocompleteInput from '../../src/components/AutocompleteInput.jsx'
 
-Add an address autocomplete widget to your site with just a few lines of code.
+Use Radar's autocomplete component to add address autocomplete to your websites and apps with just a few lines of code.
 
 <AutocompleteInput />
 
 ## How it works
 
-To use the Radar Autocomplete input, simply initialize the Radar SDK with your publishable key, and specify the container to render the input into.
+To use the autocomplete component, simply initialize the Radar SDK with your publishable key, and specify the container to render the input into.
 
 ## Configuration
 
@@ -17,27 +17,28 @@ When creating the Autocomplete input, you can provide options to customize the a
 
 <div class="full-width-table">
 
-| Name  | Default | Possible Values | Description           | SDK availability |
+| Name  | Default | Possible values | Description           | SDK availability |
 |-------|---------|-----------------|-----------------------|------------------|
-|`container` |`autocomplete` |string \| HTMLElement |The container the autocomplete input will be rendered into. Can specify the html `id`, or DOM object. <br /><br /><b>Note:</b> If an `<input>` is provided as the container, the `<input>`'s style will not be modified. |Web|
-|`width` |`400` |number \| string |Width of the input. Can be a number (in pixels) or a valid CSS width.|Web|
-|`maxHeight` |`null` |number \| string |Max height of the results list container. Can be a number (in pixels) or a valid CSS height.|Web|
-|`near` |`null` |string \| Location | The location to search. If not provided, the request IP address will be used to anchor the search. <br /><br />Can be provided as a string in the format `latitude,longitude` or as an object `{ latitude, longitude }`. |Web, React Native|
-|`debounceMS` |`200` |number |The number of milliseconds to wait after typing is complete to refresh the result list.|Web, React Native|
-|`threshold` |`3` |number |Minimum number of characters that need to be typed before fetching results.|Web, React Native|
-|`limit` |`8` |number |Maximum number of results to show.|Web, React Native|
-|`onSelection` |`null` |function `(address) => {}`|Callback with selected address.|Web, React Native|
-|`onResults` |`null` |function `(addresses) => {}`|Callback with list of address results.|Web, React Native|
-|`onError` |`null` |function `(error) => {}`|Callback with any errors that occur.|Web, React Native|
-|`placeholder` |`Search address` |string |Input placeholder text|Web, React Native|
-|`responsive` |`true` |boolean |Whether the input should expand to fill the parent container or not. If `responsive` is true _and_ a `width` is provided, `width` will be treated as a "max-width".|Web|
-|`disabled` |`false` |boolean |Disables the input.|Web, React Native|
-|`layers` |`null` |`place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, `fine` |Filter results by layer type. See [Autocomplete docs](/documentation/api#query-parameters-3) for more info.|Web, React Native|
-|`countryCode` |`null` |string|2-letter country code to filter results by.|Web, React Native|
-|`expandUnits` |`false` |boolean|Whether to include unit numbers in the results.|Web|
-|`showMarkers` |`true` |boolean |Show map pin icons next to results in the list.|Web, React Native|
-|`markerColor` |`#ACBDC8` |string |CSS color for marker icon.|Web|
-|`style`|`null`|React Native style object|Styles for the element. See the [code](https://github.com/radarlabs/react-native-radar/blob/be23434ba731dda7015e25b7fc3a6364ff1b311d/js/ui/autocomplete.jsx#L153) for specifics.|React Native|
+| `container` | `autocomplete` | string \| HTMLElement | The container to render the map into. You can specify an `id` of an HTML element or a DOM element. If an `<input>` is provided as a container, the style of the input will not be modified. | Web |
+| `width` | `400` | number \| string | The width of the input, a number (in pixels) or any valid CSS width. | Web |
+| `maxHeight` | `null` | number \| string | The max height of the results list, a number (in pixels) or any valid CSS height. | Web |
+| `near` | `null` | string \| Location | The location to search near, in the format `"latitude,longitude"` or `{ latitude, longitude }`. If not specified, the search will automatically be biased based on the client's [IP geolocation](/documentation/api#ip-geocode). | Web, React Native |
+| `debounceMS` | `200` | number | The number of milliseconds to wait after typing is complete to refresh the results list. | Web, React Native |
+| `threshold` | `3` | number | The minimum number of characters that need to be typed before fetching results. | Web, React Native |
+| `limit` | `8` | number | The maximum number of results to show in the results list. | Web, React Native |
+| `onSelection` | `null` | function `(address) => {}` | A function called when a result is selected from the results list. | Web, React Native |
+| `onResults` | `null` | function `(addresses) => {}` | A function called when the results list is refreshed. | Web, React Native |
+| `onError`  | `null` | function `(error) => {}` | A function called if any errors occur. | Web, React Native |
+| `placeholder` | `Search address` | string | The placeholder string for the input. | Web, React Native |
+| `responsive` | `true` | boolean | A boolean that indicates whether the input should expand to fill the parent container. If `responsive = true` and a `width` is specified, `width` will be treated as a `max-width`. | Web |
+| `disabled` | `false` | boolean | A boolean that indicates whether the input should be disabled. | Web, React Native |
+| `layers` | `null` | array | Optional layer filters. An array including one or more of `place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, and `fine`. See the [autocomplete API documentation](https://radar.com/documentation/api#autocomplete) for more info. | Web, React Native |
+| `countryCode` | `null` | string | 2-letter country code to filter results by. | Web, React Native |
+| `expandUnits` | `false` | boolean | A boolean that indicates whether to include unit numbers in the results. | Web |
+| `showMarkers` | `true` | boolean | A boolean that indicates whether to show marker icons in the results list. | Web, React Native |
+| `markerColor`  | `#acbdc8` | string | The CSS color of marker icons in the results list. | Web |
+| `style` | `null` | React Native style object | Styles for the element. See the [code](https://github.com/radarlabs/react-native-radar/blob/master/js/ui/autocomplete.jsx) for more info. | React Native |
+
 </div>
 
 ## Quickstart
@@ -64,7 +65,6 @@ Then, get started with the sample code below.
     <script type="text/javascript">
       Radar.initialize('prj_live_pk_...');
 
-      // create autocomplete input
       Radar.ui.autocomplete({
         container: 'autocomplete',
         width: '600px',
@@ -86,22 +86,14 @@ import Radar, { Autocomplete } from 'react-native-radar';
 
 Radar.initialize('prj_live_pk_...');
 
-export default function App() {
-  const onSelection = (selectedAddress) => {
-    // Do something with the selected address
-  }
-
-  return (
-      <View style={{ marginTop: 50 }}>
-          <Autocomplete options={
-            onSelection,
-            near: {
-              latitude: 40.7342,
-              longitude: -73.9911,
-            }
-          } />
-      </View>
-  );
-}
+export const App = () => (
+  <View>
+    <Autocomplete options={
+      onSelection: (address) => {
+        // do something with selected address
+      },
+    } />
+  </View>
+);
 ```
 

--- a/docs/maps/autocomplete.mdx
+++ b/docs/maps/autocomplete.mdx
@@ -15,6 +15,8 @@ To use the autocomplete component, simply initialize the Radar SDK with your pub
 
 When creating the Autocomplete input, you can provide options to customize the autocomplete behavior, as well as the size of the input.
 
+Available options include:
+
 <div class="full-width-table">
 
 | Name  | Default | Possible values | Description           | SDK availability |

--- a/docs/maps/autocomplete.mdx
+++ b/docs/maps/autocomplete.mdx
@@ -9,7 +9,7 @@ Use Radar's autocomplete component to add address autocomplete to your websites 
 
 ## How it works
 
-To use the autocomplete component, simply initialize the Radar SDK with your publishable key, and specify the container to render the input into.
+To use the autocomplete component, simply initialize the Radar SDK with your publishable key and specify the container to render the input into.
 
 ## Configuration
 
@@ -17,7 +17,7 @@ When creating the Autocomplete input, you can provide options to customize the a
 
 Available options include:
 
-<div class="full-width-table">
+<div className="full-width-table">
 
 | Name  | Default | Possible values | Description           | SDK availability |
 |-------|---------|-----------------|-----------------------|------------------|

--- a/docs/maps/autocomplete.mdx
+++ b/docs/maps/autocomplete.mdx
@@ -35,7 +35,7 @@ Available options include:
 | `responsive` | `true` | boolean | A boolean that indicates whether the input should expand to fill the parent container. If `responsive = true` and a `width` is specified, `width` will be treated as a `max-width`. | Web |
 | `disabled` | `false` | boolean | A boolean that indicates whether the input should be disabled. | Web, React Native |
 | `layers` | `null` | array | Optional layer filters. An array including one or more of `place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, and `fine`. See the [autocomplete API documentation](https://radar.com/documentation/api#autocomplete) for more info. | Web, React Native |
-| `countryCode` | `null` | string | 2-letter country code to filter results by. | Web, React Native |
+| `countryCode` | `null` | string | An optional 2-letter [ISO 3166](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes) country code. If set, results will only be fetched from the specified country. | Web, React Native |
 | `expandUnits` | `false` | boolean | A boolean that indicates whether to include unit numbers in the results. | Web |
 | `showMarkers` | `true` | boolean | A boolean that indicates whether to show marker icons in the results list. | Web, React Native |
 | `markerColor`  | `#acbdc8` | string | The CSS color of marker icons in the results list. | Web |

--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -10,7 +10,7 @@ For example, here's a Radar Map displaying a marker for Radar HQ:
 
 <Map />
 
-You can also check out a full-page [maps demo](/demo/maps) or [store locator demo](/demo/locator), or check out the [Maps explorer page](https://radar.com/dashboard/settings) in the dashboard.
+You can also check out a full-page [maps demo](/demo/maps) or [store locator demo](/demo/locator), or check out the [Maps explorer page](https://radar.com/dashboard/maps/maps-explorer/maps) in the dashboard.
 
 ## How it works
 

--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -20,14 +20,14 @@ Radar Maps is an extension of the [MapLibre GL JS](https://maplibre.org) library
 
 ## Configuration
 
-You can configure a map with any of the `[MapOptions](https://maplibre.org/maplibre-gl-js/docs/API/types/maplibregl.MapOptions/)` available in MapLibre.
+You can configure a map with any MapLibre [MapOptions](https://maplibre.org/maplibre-gl-js/docs/API/types/maplibregl.MapOptions/).
 
 The minimum recommended options are the following:
 
 <div class="full-width-table">
 
-| Name  | Default | Possible values | Description           | SDK availability |
-|-------|---------|-----------------|-----------------------|------------------|
+| Name  | Default | Possible values | Description           |
+|-------|---------|-----------------|-----------------------|
 | `container` | none (required) | string \| HTMLElement | The container to render the map into. You can specify an `id` of an HTML element or a DOM element. The width and height of this element will determine the size of the map. |
 | `style` | `radar-default-v1` | `radar-default-v1`, `radar-light-v1`, `radar-dark-v1` | The style of the map. See below for more details. |
 | `center` | none (IP geolocation) | `[longitude, latitude]` | The center of the map. If not specified, the map will  automatically be centered based on the client's [IP geolocation](/documentation/api#ip-geocode). |
@@ -95,7 +95,7 @@ To create a simple web page with a map:
     <script type="text/javascript">
       Radar.initialize('prj_live_pk_...');
 
-      // create a new map
+      // create a map
       const map = Radar.ui.map({
         container: 'map',
         style: 'radar-default-v1',
@@ -103,7 +103,7 @@ To create a simple web page with a map:
         zoom: 11
       });
 
-      // create marker and add to map
+      // add a marker to the map
       const marker = Radar.ui.marker({ text: 'Radar HQ' })
         .setLngLat([-73.9910078, 40.7342465])
         .addTo(map);
@@ -132,6 +132,7 @@ class RadarMap extends React.Component {
   componentDidMount() {
     Radar.initialize('prj_live_pk_...');
 
+    // create a map
     const map = new Radar.ui.map({
       container: 'map',
       style: 'radar-default-v1',
@@ -139,6 +140,7 @@ class RadarMap extends React.Component {
       zoom: 14,
     });
 
+    // add a marker to the map
     Radar.ui.marker({ text: 'Radar HQ' })
       .setLngLat([-73.9910078, 40.7342465])
       .addTo(map);
@@ -186,6 +188,7 @@ export default {
     onMounted(() => {
       Radar.initialize('prj_live_pk_...');
 
+      // create a map
       map.value = markRaw(Radar.ui.map({
         container: mapRef.value,
         style: 'radar-default-v1',
@@ -193,6 +196,7 @@ export default {
         zoom: 11
       }));
 
+      // add a marker to the map
       Radar.ui.Marker({ color: '#007aff' })
         .setLngLat([-73.9911, 40.7342]) // Radar HQ
         .addTo(map.value);
@@ -377,7 +381,7 @@ struct MapView: UIViewRepresentable {
           animated: false
         )
         
-        // add Radar logo
+        // add the Radar logo
 
         let logoImageView = UIImageView(image: UIImage(named: "radar-logo"))
         logoImageView.translatesAutoresizingMaskIntoConstraints = false

--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -292,7 +292,7 @@ To add a marker to the map and control the camera:
           _id: '123',
         },
         geometry: {
-          type: "Point",
+          type: 'Point',
           coordinates: [-73.9911, 40.7342]
         }
       }

--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -10,62 +10,34 @@ For example, here's a Radar Map displaying a marker for Radar HQ:
 
 <Map />
 
+You can also check out a full-page [maps demo](/demo/maps) or [store locator demo](/demo/locator), or check out the [Maps explorer page](https://radar.com/dashboard/settings) in the dashboard.
+
 ## How it works
 
 To use Radar Maps, simply initialize the Radar SDK with your publishable key, and specify the container to render the map into.
 
-Radar Maps is an extension of the [Maplibre GL JS](https://maplibre.org) library. See their [docs](https://maplibre.org/maplibre-gl-js/docs/API/) for additional customization info.
+Radar Maps is an extension of the [MapLibre GL JS](https://maplibre.org) library. See their [docs](https://maplibre.org/maplibre-gl-js/docs/API/) for more customization info.
 
 ## Configuration
 
-When creating a new Radar map, you can configure it with any of the [MapOptions](https://maplibre.org/maplibre-gl-js/docs/API/types/maplibregl.MapOptions/) available in MapLibre.
+You can configure a map with any of the `[MapOptions](https://maplibre.org/maplibre-gl-js/docs/API/types/maplibregl.MapOptions/)` available in MapLibre.
 
-The minimum recommended configuration options are the following:
+The minimum recommended options are the following:
 
-<table class="full-width-table">
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th class="no-wrap">Default</th>
-      <th class="no-wrap">Possible Values</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>container</code></td>
-      <td class="no-wrap">none (required)</td>
-      <td class="no-wrap">string | HTMLElement</td>
-      <td>The <code>id</code> or HTML element the map will be rendered into. <br /> <br /><em>The width and height of this element will determine the size of the map</em></td>
-    </tr>
-    <tr>
-      <td><code>style</code></td>
-      <td class="no-wrap"><code>radar-default-v1</code></td>
-      <td class="no-wrap"><code>radar-default-v1</code>, <br /><code>radar-light-v1</code>, <br /><code>radar-dark-v1</code></td>
-      <td>The map's style. See below for more details on map styles</td>
-    </tr>
-    <tr>
-      <td><code>center</code></td>
-      <td class="no-wrap"><em>IP Geolocation</em></td>
-      <td class="no-wrap"><code>[longitude, latitude]</code></td>
-      <td>The initial map center point.</td>
-    </tr>
-    <tr>
-      <td><code>zoom</code></td>
-      <td class="no-wrap">11</td>
-      <td class="no-wrap">number</td>
-      <td>The initial map zoom level.</td>
-    </tr>
-  </tbody>
-</table>
+<div class="full-width-table">
 
-<Alert alertType='tip'>
-   Web-based maps will be automatically centered based on the user's IP Geolocation unless center and zoom properties are specified.
-</Alert>
+| Name  | Default | Possible values | Description           | SDK availability |
+|-------|---------|-----------------|-----------------------|------------------|
+| `container` | none (required) | string \| HTMLElement | The container to render the map into. You can specify an `id` of an HTML element or a DOM element. The width and height of this element will determine the size of the map. |
+| `style` | `radar-default-v1` | `radar-default-v1`, `radar-light-v1`, `radar-dark-v1` | The style of the map. See below for more details. |
+| `center` | none (IP geolocation) | `[longitude, latitude]` | The center of the map. If not specified, the map will  automatically be centered based on the client's [IP geolocation](/documentation/api#ip-geocode). |
+| `zoom` | 11 | number | The zoom level of the map, a number between 0 (fully zoomed out) and 23 (fully zoomed in). |
+
+</div>
 
 ### Styles
 
-Radar provides several out-of-the box styles tailored to various use cases.
+Radar provides several out-of-the box map styles:
 
 <table class="full-width-table">
   <thead>
@@ -89,7 +61,7 @@ Radar provides several out-of-the box styles tailored to various use cases.
     <tr>
       <td class="no-wrap"><code>radar-dark-v1</code></td>
       <td style={{ width: "400px" }}><img width="400" src="https://images.ctfassets.net/f2vbu16fzuly/UhZJgEo57528CJRQCj0fT/3a2e2dc29205da1a9ea8e60b52dcafa6/radar-dark-theme.png?w=1200" /></td>
-      <td>A dark monochrome map style, useful for highlighting your own information or visualizations in a dark mode setting.</td>
+      <td>A dark monochrome map style, useful for highlighting your own information or visualizations in dark mode.</td>
     </tr>
   </tbody>
 </table>
@@ -113,8 +85,8 @@ To create a simple web page with a map:
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-    <link href="https://js.radar.com/v4.1.6/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.1.6/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.1.11/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.1.11/radar.min.js"></script>
   </head>
 
   <body>
@@ -144,13 +116,13 @@ To create a simple web page with a map:
 
 To create a [React](https://react.dev) component with a map:
 
-<Alert alertType='info'>
-  The Radar SDK has a dependency on maplibre-gl for the map rendering.
-</Alert>
-
 ```bash
 npm install --save radar-sdk-js maplibre-gl
 ```
+
+<Alert alertType='info'>
+  `radar-sdk-js` has a dependency on `maplibre-gl`.
+</Alert>
 
 ```jsx
 import React from 'react';
@@ -263,40 +235,39 @@ body {
 
 To create a [React Native](https://react.dev) component with a map:
 
-<Alert alertType='info'>
-  The Radar SDK has a dependency on maplibre-react-native for the map rendering.
-</Alert>
-
 ```bash
 npm install --save react-native-radar @maplibre/maplibre-react-native
 ```
 
-Next, complete any required [platform specific installation steps](https://github.com/maplibre/maplibre-react-native/blob/main/docs/GettingStarted.md#review-platform-specific-info).
+<Alert alertType='info'>
+  `react-native-radar` has a dependency on `maplibre-gl`.
+</Alert>
 
+Next, complete any required [platform-specific installation steps](https://github.com/maplibre/maplibre-react-native/blob/main/docs/GettingStarted.md#review-platform-specific-info).
 
-Get started by initializing the Radar SDK and using `<Map>`:
+Finally, initialize the Radar SDK and add a `<Map>` component:
 
 ```jsx
 import { View } from 'react-native';
 import Radar, { Map } from 'react-native-radar';
 import MapLibreGL from '@maplibre/maplibre-react-native';
 
-    
-// MapLibre requires setting their deprecated access token to null
+// NOTE: MapLibre requires setting their deprecated access token to null
 MapLibreGL.setAccessToken(null);
 
 Radar.initialize('prj_live_pk_...');
 
-export default function App() {
-    return (
-        <View style={{ width: '100%', height: '95%'}}>
-            <Map />
-        </View>
-    );
-}
+export const App = () => (
+  <View style={{ width: '100%', height: '95%' }}>
+    <Map />
+  </View>
+);
 ```
 
-You can also add custom pins to the map and control the camera:
+Optionally, add assets for a marker. You can download assets [here](/img/radar-map-assets.zip).
+
+To add a marker to the map and control the camera:
+
 ```jsx
   const [cameraConfig, setCameraConfig] = useState({
     triggerKey: Date.now(),
@@ -307,41 +278,40 @@ You can also add custom pins to the map and control the camera:
   });
 
   const onRegionDidChange = (event) => {
-    // handle region change
+    // do something on region change
   }
 
-  const mapOptions = {
-    onRegionDidChange: onRegionDidChange,
-  }
-
-  const onSelect = (selectedAddress) => {
-    // Do something with the selected address
+  const onSelect = (address) => {
+    // do something with selected address
   }
 
   const pointsCollection = {
-    type: "FeatureCollection",
-    features: [{
-      type: "Feature",
-      properties: {
-        _id: '123',
-      },
-      geometry: {
-        type: "Point",
-        coordinates: [-73.9911, 40.7342]
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {
+          _id: '123',
+        },
+        geometry: {
+          type: "Point",
+          coordinates: [-73.9911, 40.7342]
+        }
       }
-    }]
+    ]
   }; 
   
-  const onPressIcon = (event) => {
-    // do something with the symbol, such as scrolling to the geofence
-    // associated with the icon in the list
+  const onPress = (event) => {
+    // do something on press
   }
     
   return (
-    <View style={{ width: '100%', marginTop: '10%', height: '90%'}}>
-      <Map mapOptions={mapOptions}>
+    <View style={{ width: '100%', marginTop: '10%', height: '90%' }}>
+      <Map mapOptions={{
+        onRegionDidChange,
+      }}>
         <MapLibreGL.Camera
-        {...cameraConfig}
+          {...cameraConfig}
         />
         <MapLibreGL.Images
           images={{
@@ -351,10 +321,9 @@ You can also add custom pins to the map and control the camera:
         <MapLibreGL.ShapeSource
           id="points"
           shape={pointsCollection}
-          onPress={onPressIcon}
+          onPress={onPress}
         >
-
-         <MapLibreGL.SymbolLayer
+        <MapLibreGL.SymbolLayer
             id="symbol"
             style={{
               iconImage: 'icon',
@@ -362,9 +331,9 @@ You can also add custom pins to the map and control the camera:
                 'interpolate',
                 ['linear'],
                 ['zoom'],
-                0, 0.2, // Adjust the icon size for zoom level 0
-                12, 0.4, // Adjust the icon size for zoom level 12
-                22, 0.8, // Adjust the icon size for zoom level 22
+                0, 0.2, // adjust the icon size for zoom level 0
+                12, 0.4, // adjust the icon size for zoom level 12
+                22, 0.8, // adjust the icon size for zoom level 22
               ],
               iconAllowOverlap: true,
             }}
@@ -377,21 +346,15 @@ You can also add custom pins to the map and control the camera:
 
 ### iOS
 
-Radar maps can be integrated into an iOS application with [MapLibre Native](https://github.com/maplibre/maplibre-native).
+To create a map on iOS, add [MapLibre Native](https://github.com/maplibre/maplibre-native) to your Xcode project.
 
-To get started, add the MapLibre Native package to your XCode project.
+Then, add assets for the Radar logo and optionally for a marker. You can download assets [here](/img/radar-map-assets.zip).
 
-`General` > `Frameworks, Libraries, and Embedded Content` > `Add item` > `Add other` > `Add package dependency`
-
-<p>
-  <img src="https://images.ctfassets.net/f2vbu16fzuly/2os3Ew3JE6Ch0fStG0TnGT/73038669bcf2ab31e50d83adff31fb55/Screenshot_2023-07-21_at_3.47.18_PM.png?w=2400" alt="XCode add MapLibre dependency screenshot" />
-</p>
-
-Then, add the map to your ViewController with Radar's style URL and your publishable key.
+Finally, add a `MapView` to a `ViewController` with a Radar style URL that includes your publishable key:
 
 ```swift
 import SwiftUI
-import Mapbox // NOTE: the MapLibre package is imported as "Mapbox"
+import Mapbox // NOTE: MapLibre is imported as Mapbox
 
 struct MapView: UIViewRepresentable {
     
@@ -400,29 +363,23 @@ struct MapView: UIViewRepresentable {
     }
     
     func makeUIView(context: Context) -> MGLMapView {
-    
-        // ========================
-        // Setup Map
-        // ========================
+        // create a map
 
-        // create url (style + publishable key)
-        let styleURL = URL(string: "https://api.radar.io/maps/styles/radar-default-v1?publishableKey=prj_live_pk...")
+        let style = "radar-default-v1"
+        let publishableKey = "prj_live_pk..."
+        let styleURL = URL(string: "https://api.radar.io/maps/styles/\(style)?publishableKey=\(publishableKey)")
 
-        // create the map view
         let mapView = MGLMapView(frame: .zero, styleURL: styleURL)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.logoView.isHidden = true
 
-        // set the map’s center coordinate and zoom level.
         mapView.setCenter(
           CLLocationCoordinate2D(latitude: 40.7342, longitude: -73.9911),
           zoomLevel: 11,
           animated: false
         )
         
-        // ========================
-        // Add Logo
-        // ========================
+        // add Radar logo
 
         let logoImageView = UIImageView(image: UIImage(named: "radar-logo"))
         logoImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -440,9 +397,12 @@ struct MapView: UIViewRepresentable {
         return mapView
     }
     
-    func updateUIView(_ uiView: MGLMapView, context: Context) {}
+    func updateUIView(_ uiView: MGLMapView, context: Context) {
+
+    }
     
-    // Responds to map events
+    // add a marker on map load
+
     class Coordinator: NSObject, MGLMapViewDelegate {
         var control: MapView
 
@@ -450,31 +410,24 @@ struct MapView: UIViewRepresentable {
             self.control = control
         }
 
-        // Add marker to map after loading
         func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
             addMarker(style: style, coordinate: CLLocationCoordinate2D(latitude: 40.7342, longitude: -73.9911))
         }
 
         func addMarker(style: MGLStyle, coordinate: CLLocationCoordinate2D) {
-            // create point to place marker
             let point = MGLPointAnnotation()
             point.coordinate = coordinate
 
-            // create data source to hold point data
             let shapeSource = MGLShapeSource(identifier: "marker-source", shape: point, options: nil)
 
-            // create a style layer for the symbol
             let shapeLayer = MGLSymbolStyleLayer(identifier: "marker-style", source: shapeSource)
 
-            // add image to the style's sprites
             if let image = UIImage(named: "default-marker") {
                 style.setImage(image, forName: "marker")
             }
 
-            // tell the layer to use the image in the sprite
             shapeLayer.iconImageName = NSExpression(forConstantValue: "marker")
 
-            // add the source and style layer to the map
             style.addSource(shapeSource)
             style.addLayer(shapeLayer)
         }
@@ -482,35 +435,25 @@ struct MapView: UIViewRepresentable {
 }
 ```
 
-You can find the assets used for the pin and Radar logo [here](/img/radar-map-assets.zip).
-
 <Alert alertType="info">
-  Logo placement is required as defined in the <a href="https://radar.com/terms">Terms of Use</a>.
+  Adding a Radar logo to the map is required in our <a href="https://radar.com/terms">Terms of Use</a>.
 </Alert>
 
 ### Android
 
-Radar maps can be integrated into an Android application with [MapLibre Native](https://github.com/maplibre/maplibre-native).
+To create a map on Android, add [MapLibre Native](https://github.com/maplibre/maplibre-native) to the `dependencies` section of your app's `build.gradle` file:
 
-To get started, add the MapLibre Native dependency into your module Gradle file (usually located at `<project>/<app-module>/build.gradle`). Replace `<version>` with the latest MapLibre Native version (e.g.: `org.maplibre.gl:android-sdk:10.2.0`).
-
-```kotlin
+```gradle
 dependencies {
-    ...
-    implementation 'org.maplibre.gl:android-sdk:<version>'
-    ...
+    implementation 'org.maplibre.gl:android-sdk:10.2.0'
 }
 ```
 
-Then, import the Radar Map assets. Go to `View` > `Tool Windows` > `Resource Manager`. Click the + button below Resource Manager and select "Import Drawables." Import the radar map assets you need for your application. The assets can be found below this section.
+Import assets for the Radar logo and optionally for a marker. You can download assets [here](/img/radar-map-assets.zip).
 
-<p>
-  <img src="https://images.ctfassets.net/f2vbu16fzuly/5I4DeUd6fkwDgfO5mk62dt/8148400ae165abaa6a1bebaae973a18a/image.png?w=2400" alt="XCode add MapLibre dependency screenshot" />
-</p>
-
-Next, open your layout XML file where you want to display the radar map. Add a MapView element to the layout:
+Then, add a `MapView` with the Radar logo to your layout:
   
-```html
+```xml
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -525,7 +468,6 @@ Next, open your layout XML file where you want to display the radar map. Add a M
         android:layout_height="match_parent"
         />
 
-    <!-- The radar logo -->
     <ImageView
         android:id="@+id/overlayImageView"
         android:layout_width="wrap_content"
@@ -539,8 +481,7 @@ Next, open your layout XML file where you want to display the radar map. Add a M
 </androidx.constraintlayout.widget.ConstraintLayout>
 ```
 
-Finally, initialize the `MapView` in your activity file with Radar's style URL and your publishable key. Add a pin to the map. Remember to use the assets you imported earlier for the pin and Radar logo.
-
+Finally, add a `MapView` in your `Activity` with a Radar style URL that includes your publishable key:
 
 ```kotlin
 import android.os.Bundle
@@ -550,7 +491,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.toBitmap
 
-// the MapLibre package is imported as "Mapbox"
+// NOTE: MapLibre is imported as Mapbox
 import com.mapbox.mapboxsdk.Mapbox
 import com.mapbox.mapboxsdk.annotations.IconFactory
 import com.mapbox.mapboxsdk.annotations.MarkerOptions
@@ -567,54 +508,51 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // create url (style + publishable key)
-        val key = "prj_live_pk_..."
-        val style = "radar-default-v1"
-        val styleURL = "https://api.radar.io/maps/styles/$style?publishableKey=$key"
+        // create a map
 
-        // init MapLibre
+        val style = "radar-default-v1"
+        val publishableKey = "prj_live_pk_..."
+        val styleURL = "https://api.radar.io/maps/styles/$style?publishableKey=$publishableKey"
+
         Mapbox.getInstance(this)
 
-        // init layout view
         val inflater = LayoutInflater.from(this)
         val rootView = inflater.inflate(R.layout.activity_main, null)
         setContentView(rootView)
 
-        // init the MapView
         mapView = rootView.findViewById(R.id.mapView)
 
         mapView.getMapAsync { map ->
-            // callback for map done loading
             mapboxMap = map
-            // remove default logo and replace with Radar logo in activity_main.xml
+
+            // add the Radar logo
+
             map.uiSettings.isLogoEnabled = false
 
-            // anchor attribution to bottom right
             map.uiSettings.attributionGravity = Gravity.RIGHT + Gravity.BOTTOM
-            map.uiSettings.setAttributionMargins(0,0,24,24)
+            map.uiSettings.setAttributionMargins(0, 0, 24, 24)
 
             map.setStyle(styleURL)
-            // add marker, set map's center coordinate and zoom level
-            addMarker(LatLng(40.7342,-73.9911))
-            map.cameraPosition = CameraPosition.Builder().target(LatLng(40.7342,-73.9911)).zoom(11.0).build()
+
+            // add a marker on map load
+
+            addMarker(LatLng(40.7342, -73.9911))
+            map.cameraPosition = CameraPosition.Builder().target(LatLng(40.7342, -73.9911)).zoom(11.0).build()
         }
 
     }
 
-    private fun addMarker(coordinate: LatLng){
-        // get bitmap for marker icon
+    private fun addMarker(coordinate: LatLng) {
         val infoIconDrawable = ResourcesCompat.getDrawable(
             this.resources,
-            // use imported marker resource
             R.drawable.default_marker,
             null
         )!!
-        // create icon bmp
+
         val bitmapMarker = infoIconDrawable.toBitmap()
         val icon = IconFactory.getInstance(this)
             .fromBitmap(bitmapMarker)
 
-        // create point to place marker
         val markerOptions = MarkerOptions()
             .position(coordinate)
             .icon(icon)
@@ -657,8 +595,6 @@ class MainActivity : AppCompatActivity() {
     }
 }
 ```
-
-You can find the assets used for the pin and Radar logo [here](/img/radar-map-assets.zip).
 
 <Alert alertType="info">
   Logo placement is required as defined in the <a href="https://radar.com/terms">Terms of Use</a>.

--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -120,9 +120,7 @@ To create a [React](https://react.dev) component with a map:
 npm install --save radar-sdk-js maplibre-gl
 ```
 
-<Alert alertType='info'>
-  `radar-sdk-js` has a dependency on `maplibre-gl`.
-</Alert>
+The SDK has a dependency on [maplibre-gl](https://github.com/maplibre/maplibre-gl-js).
 
 ```jsx
 import React from 'react';
@@ -165,6 +163,8 @@ To create a [Vue](https://vuejs.org) component with a map:
 ```bash
 npm install --save radar-sdk-js maplibre-gl
 ```
+
+The SDK has a dependency on [maplibre-gl](https://github.com/maplibre/maplibre-gl-js).
 
 ```javascript
 <template>
@@ -239,9 +239,7 @@ To create a [React Native](https://react.dev) component with a map:
 npm install --save react-native-radar @maplibre/maplibre-react-native
 ```
 
-<Alert alertType='info'>
-  `react-native-radar` has a dependency on `maplibre-gl`.
-</Alert>
+The SDK has a dependency on [maplibre-react-native](https://github.com/maplibre/maplibre-react-native).
 
 Next, complete any required [platform-specific installation steps](https://github.com/maplibre/maplibre-react-native/blob/main/docs/GettingStarted.md#review-platform-specific-info).
 

--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -10,7 +10,7 @@ For example, here's a Radar Map displaying a marker for Radar HQ:
 
 <Map />
 
-You can also check out a full-page [maps demo](/demo/maps) or [store locator demo](/demo/locator), or check out the [Maps explorer page](https://radar.com/dashboard/maps/maps-explorer/maps) in the dashboard.
+You can also check out a full-page [maps demo](https://radar.com/demo/maps) or [store locator demo](https://radar.com/demo/locator), or check out the [Maps explorer page](https://radar.com/dashboard/maps/maps-explorer/maps) in the dashboard.
 
 ## How it works
 

--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -14,7 +14,7 @@ You can also check out a full-page [maps demo](/demo/maps) or [store locator dem
 
 ## How it works
 
-To use Radar Maps, simply initialize the Radar SDK with your publishable key, and specify the container to render the map into.
+To use Radar Maps, simply initialize the Radar SDK with your publishable key and specify the container to render the map into.
 
 Radar Maps is an extension of the [MapLibre GL JS](https://maplibre.org) library. See their [docs](https://maplibre.org/maplibre-gl-js/docs/API/) for more customization info.
 
@@ -24,7 +24,7 @@ You can configure a map with any MapLibre [MapOptions](https://maplibre.org/mapl
 
 The minimum recommended options are the following:
 
-<div class="full-width-table">
+<div className="full-width-table">
 
 | Name  | Default | Possible values | Description           |
 |-------|---------|-----------------|-----------------------|
@@ -39,27 +39,27 @@ The minimum recommended options are the following:
 
 Radar provides several out-of-the box map styles:
 
-<table class="full-width-table">
+<table className="full-width-table">
   <thead>
     <tr>
-      <th class="no-wrap">Style</th>
+      <th className="no-wrap">Style</th>
       <th style={{ width: "400px" }}>Preview</th>
       <th>Description</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td class="no-wrap"><code>radar-default-v1</code></td>
+      <td className="no-wrap"><code>radar-default-v1</code></td>
       <td style={{ width: "400px" }}><img width="400" src="https://images.ctfassets.net/f2vbu16fzuly/1wBEmydpkmmP5eI23nHD6s/1a628636b92095173b946da3a3e6204e/radar-default-theme.png?w=1200" /></td>
       <td>Radar's default map style, showcasing detailed street-level information about roads and nearby places. A general purpose map suitable for most use cases.</td>
     </tr>
     <tr>
-      <td class="no-wrap"><code>radar-light-v1</code></td>
+      <td className="no-wrap"><code>radar-light-v1</code></td>
       <td style={{ width: "400px" }}><img width="400" src="https://images.ctfassets.net/f2vbu16fzuly/39PJYbWntW8cK4NnP33cWK/ae8ad63d9e300a3c8d61ce47f7323914/radar-light-theme.png?w=1200" /></td>
       <td>A light monochrome map style, useful for highlighting your own information or visualizations.</td>
     </tr>
     <tr>
-      <td class="no-wrap"><code>radar-dark-v1</code></td>
+      <td className="no-wrap"><code>radar-dark-v1</code></td>
       <td style={{ width: "400px" }}><img width="400" src="https://images.ctfassets.net/f2vbu16fzuly/UhZJgEo57528CJRQCj0fT/3a2e2dc29205da1a9ea8e60b52dcafa6/radar-dark-theme.png?w=1200" /></td>
       <td>A dark monochrome map style, useful for highlighting your own information or visualizations in dark mode.</td>
     </tr>
@@ -599,7 +599,7 @@ class MainActivity : AppCompatActivity() {
 ```
 
 <Alert alertType="info">
-  Logo placement is required as defined in the <a href="https://radar.com/terms">Terms of Use</a>.
+  Adding a Radar logo to the map is required in our <a href="https://radar.com/terms">Terms of Use</a>.
 </Alert>
 
 ## Coverage

--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -10,7 +10,7 @@ For example, here's a Radar Map displaying a marker for Radar HQ:
 
 <Map />
 
-You can also check out a full-page [maps demo](https://radar.com/demo/maps) or [store locator demo](https://radar.com/demo/locator), or check out the [Maps explorer page](https://radar.com/dashboard/maps/maps-explorer/maps) in the dashboard.
+You can also check out the [maps explorer](https://radar.com/dashboard/maps/maps-explorer/maps) in the dashboard, or check out a full-page [maps demo](https://radar.com/demo/maps) and [store locator demo](https://radar.com/demo/locator).
 
 ## How it works
 

--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -621,11 +621,9 @@ Radar.logConversion(
   // optionally, do something with err
 });
 ```
-### Maps & UI Kits
+### Maps and UI kits
 
-In addition to APIs, the Radar React Native SDK has built-in UI components for building rich user experiences powered by Radar.
-
-See more info in the [Maps Platform](/documentation/maps/maps) overview.
+The React Native SDK also has UI components for maps and address autocomplete. Learn more in the [Maps Platform documentation](/documentation/maps/overview).
 
 ## Support
 

--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -58,7 +58,7 @@ Radar.initialize('prj_live_pk_...', {
 
 Available options include:
 
-<div class="full-width-table">
+<div className="full-width-table">
 
 | Name  | Default | Possible values | Description           |
 |-------|---------|-----------------|-----------------------|

--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -11,11 +11,11 @@ The source can be found on GitHub [here](https://github.com/radarlabs/radar-sdk-
 
 ## Install
 
-In an HTML page, include the SDK script and corresponding stylesheet:
+In an HTML page, add the SDK script and stylesheet:
 
 ```html
-<link href="https://js.radar.com/v4.1.6/radar.css" rel="stylesheet">
-<script src="https://js.radar.com/v4.1.6/radar.min.js"></script>
+<link href="https://js.radar.com/v4.1.11/radar.css" rel="stylesheet">
+<script src="https://js.radar.com/v4.1.11/radar.min.js"></script>
 ```
 
 In a web app, install the package from npm:
@@ -23,14 +23,12 @@ In a web app, install the package from npm:
 ```bash
 npm install --save radar-sdk-js maplibre-gl
 ```
-<Alert alertType='info'>
-  The Radar SDK has a dependency on maplibre-gl for map rendering.
-</Alert>
+The SDK has a dependency on [maplibre-gl](https://github.com/maplibre/maplibre-gl-js).
 
-Then import the library and corresponding stylesheet:
+Then, import the library and stylesheet:
+
 ```javascript
 import Radar from 'radar-sdk-js';
-
 import 'radar-sdk-js/dist/radar.css';
 ```
 
@@ -38,17 +36,17 @@ import 'radar-sdk-js/dist/radar.css';
 
 ### Initialize
 
-To initialize the library, call the initialize function with a Radar publishable API key:
+Initialize the library with your publishable API key, found on the [Settings page](https://radar.com/dashboard/settings):
 
 ```javascript
 Radar.initialize('prj_live_pk_...');
 ```
 
 <Alert alertType='info'>
-  Initialization is required before calling any Radar APIs or functions.
+  You must initialize the library before calling any other functions.
 </Alert>
 
-### Configuration
+Optionally, you can specify configuration options:
 
 The initialize call takes an optional second argument that is an object with additional configuration options.
 
@@ -58,24 +56,21 @@ Radar.initialize('prj_live_pk_...', {
 });
 ```
 
-The available options are:
+Available options include:
 
 <div class="full-width-table">
 
-| Name  | Default | Possible Values | Description           |
+| Name  | Default | Possible values | Description           |
 |-------|---------|-----------------|-----------------------|
-|`logLevel` |`error` |`none`,`info`,`warn`,`error` |Determines the level logging output that is visible in the developer console. _log level will default to `error` when using a test publishable key._ |
-|`cacheLocationMinutes` |`null` |number |Number of minutes to use a previous location before re-prompting for a new location. If `null` or `0`, will always query the device for a new location. |
-|`locationMaximumAge` |`null` |number |Maximum age (in milliseconds) to use a stale browser location. See [getCurrentPosition options](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) |
-|`locationTimeout` |`30000` |number |Number of milliseconds to wait for a device location before a timeout error is thrown. Default is 30 seconds. |
-|`desiredAccuracy` |`high` |`high`,`medium`,`low` |Indicates desired level of location accuracy. _higher accuracy can result is slower response times._ |
+| `logLevel` | `error` | `none`, `info`, `warn`, `error` | Determines the log level for console logging. Defaults to `error` when using a test publishable key. |
+| `cacheLocationMinutes` | `null` | number | Determines whether to reuse previous location updates. A cache ttl in minutes. If `null` or `0`, will always request a new location. |
+| `locationMaximumAge` | `null` | number | Determines whether to use old browser locations. A maximum age in milliseconds. If `null` or `0`, will always request a new location. See [getCurrentPosition options()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition). |
+| `locationTimeout` | `30000` | number | The number of milliseconds to wait for a location update before an error is thrown. Defaults to 30 seconds. |
+| `desiredAccuracy` | `high` | `high`, `medium`, `low` | Determines the desired accuracy of location updates. Note that higher accuracy can result in slower response times. |
 
 </div>
 
-
-## Track
-
-To power [geofencing use cases](/documentation/geofencing/overview) from the web, you can leverage Radar's [track api](/documentation/api#track) to get location context and generate events.
+## Geofencing
 
 ### Identify user
 
@@ -124,7 +119,7 @@ Radar.trackOnce()
   });
 ```
 
-If the request is unsuccessful, `err` will be one of:
+If the request fails, `err` will be one of:
 
 - **`RadarPublishableKeyError`**: SDK not initialized
 - **`RadarLocationPermissionsError`**: location permissions not granted
@@ -139,26 +134,14 @@ If the request is unsuccessful, `err` will be one of:
 - **`RadarServerError`**: internal server error
 - **`RadarUnknownError`**: unknown error
 
-If the error is the result of a failed API call, additional details can be viewed by inspecting response on the error object.
+If the error is the result of a failed API call, `err` will include an HTTP response code and the API response body:
+
 ```javascript
 err.code; // HTTP response code
 err.response; // API response body
 ```
 
 ### Manual tracking
-
-It's possible to get a single device location without sending it to the server:
-
-```javascript
-Radar.getLocation()
-  .then((result) => {
-    // do something with result.location
-  })
-  .catch((err) => {
-    // handle error
-  });
-});
-```
 
 Alternatively, you can manually update the user's location with any location by calling:
 
@@ -177,6 +160,21 @@ Radar.trackOnce({
 });
 ```
 
+### Get location
+
+You can also get a single location update without sending it to the server:
+
+```javascript
+Radar.getLocation()
+  .then((result) => {
+    const { location } = result;
+    // do something with location
+  })
+  .catch((err) => {
+    // handle error
+  });
+```
+
 ### Context
 
 With the [context API](/api#context), get context for a location without sending device or user identifiers to the server:
@@ -192,15 +190,14 @@ Radar.getContext()
   });
 ```
 
-
-## Maps APIs
+## Maps
 
 ### Geocoding
 
 With the [forward geocoding API](/api#forward-geocode), geocode an address, converting address to coordinates:
 
 ```javascript
-Radar.forwardGeocode({ query: '20 jay st brooklyn ny' })
+Radar.forwardGeocode({ query: '841 broadway, new york, ny' })
   .then((result) => {
     const { addresses } = result;
     // do something with addresses
@@ -208,7 +205,6 @@ Radar.forwardGeocode({ query: '20 jay st brooklyn ny' })
   .catch((err) => {
     // handle error
   });
-});
 ```
 
 With the [reverse geocoding API](/api#reverse-geocode), reverse geocode a location, converting coordinates to address:
@@ -243,7 +239,7 @@ With the [autocomplete API](/api#autocomplete), autocomplete partial addresses a
 
 ```javascript
 Radar.autocomplete({
-  query: 'brooklyn roasting',
+  query: '841 bro',
   near: {
     latitude: 40.783826,
     longitude: -73.975363
@@ -297,19 +293,19 @@ Radar.searchPlaces({
 });
 ```
 
-With the [address validation API](/api#validate-an-address) (currently in beta), validate a structured address in the US or Canada:
+With the [address validation API](/api#validate-an-address), validate a structured address in the US or Canada:
 
 ```javascript
 Radar.validateAddress({
-  addressLabel: "841 Broadway Fl 7",
-  city: "New York",
-  stateCode: "NY",
-  postalCode: "10003",
-  countryCode: "US",
+  addressLabel: '841 BROADWAY',
+  city: 'NEW YORK',
+  stateCode: 'NY',
+  postalCode: '10003',
+  countryCode: 'US',
 })
 .then((response) => {
   const { address, result } = response;
-  // do something with validation result
+  // do something with validated address result
 })
 .catch((err) => {
   // handle error

--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -379,11 +379,9 @@ Radar.matrix({
 });
 ```
 
-## Maps & UI Kits
+## Maps and UI kits
 
-In addition to APIs, the Radar Web SDK has built-in UI components for building rich user experiences powered by Radar.
-
-See more info in the [Maps Platform](/documentation/maps/maps) overview.
+The React Native SDK also has UI components for maps and address autocomplete. Learn more in the [Maps Platform documentation](/documentation/maps/overview).
 
 ## Support
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -539,4 +539,8 @@ table .no-wrap {
   white-space: nowrap;
 }
 
+.radar-autocomplete-input {
+  font-family: 'Graphik';
+}
+
 @import '~maplibre-gl/dist/maplibre-gl.css';


### PR DESCRIPTION
Lots of small stuff, including:
- fixing a couple of typos
- cleaning up table formatting
- documenting options/params in a way that's internally consistent and consistent with other SDK docs
- bumping lib versions to the latest
- making links more "stable" (i.e., avoiding linking to anchors that might change or lines of code that might go stale)
- making terminology more consistent
- using Graphik for autocomplete component in docs
- simplifying code snippets to make them feel a little less overwhelming
- removing some Xcode/Android Studio screenshots or menu item references that will go stale quickly (and that anyone can easily Google instead)
- "Sentence case" instead of "Title Case" and other nits