### PR TITLE
added location where dependency should go

### DIFF
--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -60,7 +60,7 @@ Add the SDK to your project, preferably using CocoaPods. Finally, initialize the
 ```
 ### Android
 
-You must add Google Play Services Location to your project *(use version 21.0.1 or higher)*.
+You must add Google Play Services Location to your project's `android/app/build.gradle` *(use version 21.0.1 or higher)*.
 
 `implementation "com.google.android.gms:play-services-location:21.0.1"`
 

--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -60,7 +60,7 @@ Add the SDK to your project, preferably using CocoaPods. Finally, initialize the
 ```
 ### Android
 
-You must add Google Play Services Location to your project's `android/app/build.gradle` *(use version 21.0.1 or higher)*.
+You must add Google Play Services Location to your app's `build.gradle` file *(use version 21.0.1 or higher)*.
 
 `implementation "com.google.android.gms:play-services-location:21.0.1"`
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
One liner telling where can users install the android dependency

## Why?
<!--
  Explain the **motivation** for making this change.
-->
The previous instruction assumes the user knows where to install android dependency in the gradle file, which may not be true for novice programmers

## How?
more details were added to the instruction

## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->

## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
