### PR TITLE
address + coarse layers default for forward geocoding and search autocomplete

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -428,7 +428,7 @@ Returns a confidence level, as defined below:
 ###### Query parameters
 
 - **`query`** (string, required): The address to geocode.
-- **`layers`** (string, optional): Optional layer filters. A string, comma-separated, including one or more of `place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, and `fine`. Note that `coarse` includes all of `neighborhood`, `postalCode`, `locality`, `county`, `state`, and `country`, whereas `fine` includes all of `place`, `address`, `intersection`, and `street`. If not provided, results from all layers will be returned.
+- **`layers`** (string, optional): Optional layer filters. A string, comma-separated, including one or more of `place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, and `fine`. Note that `coarse` includes all of `neighborhood`, `postalCode`, `locality`, `county`, `state`, and `country`, whereas `fine` includes all of `place`, `address`, `intersection`, and `street`. If not provided, results from `address` and `coarse` layers will be returned.
 - **`country`** (string, optional): An optional countries filter. A string of comma-separated countries, the unique 2-letter [country code](/regions/countries).
 
 ###### Authentication level
@@ -609,7 +609,7 @@ Autocompletes partial addresses and place names, sorted by relevance.
 
 - **`query`** (string, required): The partial address or place name to autocomplete.
 - **`near`** (string, optional): The location to search. A string in the format `latitude,longitude`. If not provided, the request IP address will be used to anchor the search.
-- **`layers`** (string, optional): Optional layer filters. A string, comma-separated, including one or more of `place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, and `fine`. Note that `coarse` includes all of `neighborhood`, `postalCode`, `locality`, `county`, `state`, and `country`, whereas `fine` includes all of `place`, `address`, `intersection`, and `street`. If not provided, results from all layers will be returned.
+- **`layers`** (string, optional): Optional layer filters. A string, comma-separated, including one or more of `place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, and `fine`. Note that `coarse` includes all of `neighborhood`, `postalCode`, `locality`, `county`, `state`, and `country`, whereas `fine` includes all of `place`, `address`, `intersection`, and `street`. If not provided, results from `address` and `coarse` layers will be returned.
 - **`limit`** (number, optional): The max number of addresses to return. A number between 1 and 100. Defaults to 10.
 - **`country`** (string, optional): An optional countries filter. A string of comma-separated countries, the unique 2-letter [country code](/regions/countries).
 - **`expandUnits`** (boolean, optional): If `true`, separate results will be returned for units within buildings. Only available for `layers="address"` and for the countries `US` and `CA`. Defaults to `false`.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
Updating the default params returned for forward geocoding and search autocomplete endpoint

## Why?
These default layers are whats returned from the endpoints now

## How?

## Screenshots (optional)

<img width="944" alt="Screenshot 2023-11-06 at 12 46 00" src="https://github.com/radarlabs/documentation/assets/35515848/49cf5101-e61c-46b2-839d-d7ca7077492a">

## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
