### PR TITLE
Updates to android setForegroundOptions docs

### DIFF
--- a/docs/sdk/tracking.mdx
+++ b/docs/sdk/tracking.mdx
@@ -143,9 +143,45 @@ Option | Efficient | Responsive | Continuous
 
 To avoid [Background Location Limits](https://developer.android.com/about/versions/oreo/background-location-limits), you can start a foreground service and show a notification during tracking. If using Android SDK < [3.4.1](https://github.com/radarlabs/radar-sdk-android/releases/tag/3.1.9), set `trackingOptions.foregroundService` to an instance of `RadarTrackingOptionsForegroundService`. If using Android SDK >= [3.4.1](https://github.com/radarlabs/radar-sdk-android/blob/master/MIGRATION.md#33x-to-34x), use `Radar.setForegroundServiceOptions()` to customize the foreground service notification appearance passing in an instance of `RadarTrackingOptionsForegroundService`.
 
+<Tabs
+  groupId="setForegroundServiceOptions"
+  defaultValue="kotlin"
+  values={[
+    { label: 'Kotlin', value: 'kotlin' },
+    { label: 'React Native', value: 'reactNative' },
+  ]}
+>
+  <TabItem value="kotlin">
+
+```kotlin
+Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
+  text="Text",
+  title="Title",
+  iconString="your_icon_name",
+  updatesOnly = true
+))
+```
+
+  </TabItem>
+  <TabItem value="reactNative">
+
+```javascript
+Radar.setForegroundServiceOptions({
+  text: "Text",
+  title: "Title",
+  iconString: 'your_icon_name',
+  updatesOnly: true,
+});
+```
+
+  </TabItem>
+
+</Tabs>
+
 - **`text`**: Determines the notification text. Defaults to `"Location tracking started"`.
 - **`title`**: Determines the notification title. Optional.
-- **`icon`**: Determines the notification icon, like `R.drawable.ic_your_icon`. Optional, defaults to `applicationContext.applicationInfo.icon`.
+- **`icon`**: **Deprecated** Determines the notification icon, like `2131558400` (Android's identifier for the resource). Optional, defaults to `iconString`.
+- **`iconString`**: Determines the notification icon, like `R.drawable.ic_your_icon`. Optional, defaults to `applicationContext.applicationInfo.icon`.
 - **`updatesOnly`**: Determines when to show the notification. Use `false` to show the notification always, use `true` to show the notification only during location updates. Optional, defaults to `false`.
 - **`activity`**: Determines the activity to start when the notification is tapped, like `"com.yourapp.MainActivity"`. Optional.
 - **`importance`**: Determines the importance of the notification, one of `android.app.NotificationManager.IMPORTANCE_*`. Optional, defaults to `android.app.NotificationManager.IMPORTANCE_DEFAULT`.

--- a/docs/sdk/tracking.mdx
+++ b/docs/sdk/tracking.mdx
@@ -158,7 +158,8 @@ Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForeg
   text="Text",
   title="Title",
   iconString="your_icon_name",
-  updatesOnly=true
+  updatesOnly=true,
+  iconColor="#FF0000"
 ))
 ```
 
@@ -171,6 +172,7 @@ Radar.setForegroundServiceOptions({
   title: "Title",
   iconString: 'your_icon_name',
   updatesOnly: true,
+  iconColor: '#FF0000',
 });
 ```
 
@@ -182,6 +184,7 @@ Radar.setForegroundServiceOptions({
 - **`title`**: Determines the notification title. Optional.
 - **`icon`**: **Deprecated** Determines the notification icon, like `2131558400` (Android's identifier for the resource). Optional, defaults to `iconString`.
 - **`iconString`**: Determines the notification icon, like `R.drawable.ic_your_icon`. Optional, defaults to `applicationContext.applicationInfo.icon`.
+- **`iconColor`**: Determines the color of the notification icon. Optional.
 - **`updatesOnly`**: Determines when to show the notification. Use `false` to show the notification always, use `true` to show the notification only during location updates. Optional, defaults to `false`.
 - **`activity`**: Determines the activity to start when the notification is tapped, like `"com.yourapp.MainActivity"`. Optional.
 - **`importance`**: Determines the importance of the notification, one of `android.app.NotificationManager.IMPORTANCE_*`. Optional, defaults to `android.app.NotificationManager.IMPORTANCE_DEFAULT`.

--- a/docs/sdk/tracking.mdx
+++ b/docs/sdk/tracking.mdx
@@ -143,6 +143,17 @@ Option | Efficient | Responsive | Continuous
 
 To avoid [Background Location Limits](https://developer.android.com/about/versions/oreo/background-location-limits), you can start a foreground service and show a notification during tracking. If using Android SDK < [3.4.1](https://github.com/radarlabs/radar-sdk-android/releases/tag/3.1.9), set `trackingOptions.foregroundService` to an instance of `RadarTrackingOptionsForegroundService`. If using Android SDK >= [3.4.1](https://github.com/radarlabs/radar-sdk-android/blob/master/MIGRATION.md#33x-to-34x), use `Radar.setForegroundServiceOptions()` to customize the foreground service notification appearance passing in an instance of `RadarTrackingOptionsForegroundService`.
 
+- **`text`**: Determines the notification text. Defaults to `"Location tracking started"`.
+- **`title`**: Determines the notification title. Optional.
+- **`icon`**: Determines the notification icon via Android's identifier for the resource (e.g., `2131558400`). Optional, defaults to `iconString`. Deprecated in Android SDK [3.8.14](https://github.com/radarlabs/radar-sdk-android/releases/tag/3.8.14).
+- **`iconString`**: Determines the notification icon, like `R.drawable.ic_your_icon`. Optional, defaults to `applicationContext.applicationInfo.icon`.
+- **`iconColor`**: Determines the color of the notification icon. Optional.
+- **`updatesOnly`**: Determines when to show the notification. Use `false` to show the notification always, use `true` to show the notification only during location updates. Optional, defaults to `false`.
+- **`activity`**: Determines the activity to start when the notification is tapped, like `"com.yourapp.MainActivity"`. Optional.
+- **`importance`**: Determines the importance of the notification, one of `android.app.NotificationManager.IMPORTANCE_*`. Optional, defaults to `android.app.NotificationManager.IMPORTANCE_DEFAULT`.
+- **`id`**: Determines the id of the notification. Optional, defaults to `20160525`.
+- **`channelName`**: Determines the name of the notification channel. Optional, defaults to `"Location Services"`.
+
 <Tabs
   groupId="setForegroundServiceOptions"
   defaultValue="kotlin"
@@ -159,7 +170,6 @@ Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForeg
   title="Title",
   iconString="your_icon_name",
   updatesOnly=true,
-  iconColor="#FF0000"
 ))
 ```
 
@@ -172,24 +182,12 @@ Radar.setForegroundServiceOptions({
   title: "Title",
   iconString: 'your_icon_name',
   updatesOnly: true,
-  iconColor: '#FF0000',
 });
 ```
 
   </TabItem>
 
 </Tabs>
-
-- **`text`**: Determines the notification text. Defaults to `"Location tracking started"`.
-- **`title`**: Determines the notification title. Optional.
-- **`icon`**: **Deprecated** Determines the notification icon, like `2131558400` (Android's identifier for the resource). Optional, defaults to `iconString`.
-- **`iconString`**: Determines the notification icon, like `R.drawable.ic_your_icon`. Optional, defaults to `applicationContext.applicationInfo.icon`.
-- **`iconColor`**: Determines the color of the notification icon. Optional.
-- **`updatesOnly`**: Determines when to show the notification. Use `false` to show the notification always, use `true` to show the notification only during location updates. Optional, defaults to `false`.
-- **`activity`**: Determines the activity to start when the notification is tapped, like `"com.yourapp.MainActivity"`. Optional.
-- **`importance`**: Determines the importance of the notification, one of `android.app.NotificationManager.IMPORTANCE_*`. Optional, defaults to `android.app.NotificationManager.IMPORTANCE_DEFAULT`.
-- **`id`**: Determines the id of the notification. Optional, defaults to `20160525`.
-- **`channelName`**: Determines the name of the notification channel. Optional, defaults to `"Location Services"`.
 
 ### Android presets
 

--- a/docs/sdk/tracking.mdx
+++ b/docs/sdk/tracking.mdx
@@ -158,7 +158,7 @@ Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForeg
   text="Text",
   title="Title",
   iconString="your_icon_name",
-  updatesOnly = true
+  updatesOnly=true
 ))
 ```
 

--- a/docs/sdk/tracking.mdx
+++ b/docs/sdk/tracking.mdx
@@ -148,7 +148,7 @@ To avoid [Background Location Limits](https://developer.android.com/about/versio
   defaultValue="kotlin"
   values={[
     { label: 'Kotlin', value: 'kotlin' },
-    { label: 'React Native', value: 'reactNative' },
+    { label: 'React Native', value: 'react-native' },
   ]}
 >
   <TabItem value="kotlin">
@@ -163,7 +163,7 @@ Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForeg
 ```
 
   </TabItem>
-  <TabItem value="reactNative">
+  <TabItem value="react-native">
 
 ```javascript
 Radar.setForegroundServiceOptions({


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
<!--
  Please explain what problem your pull request is trying to solve.
  Are there any linked issues?
-->
Code snippet of implementing the `Radar.setForegroundOptions` and also updates to the fields it takes. 
## Why?
<!--
  Explain the **motivation** for making this change.
-->
An additional field, `iconString` was added so that it would be easier to determine the android asset used in the foreground service notification. 
## How?
<!--
  If you made a functional change (as opposed to just a content change):
    - How did you implement this change?
    - What decisions did you make?
-->

- Created tabs for android and react native code snippets
- Added a bullet point to explain new field.  


## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->
<img width="698" alt="image" src="https://github.com/radarlabs/documentation/assets/139801512/1800bcf1-6610-448e-ac33-00ad79fa4409">
<img width="649" alt="image" src="https://github.com/radarlabs/documentation/assets/139801512/4363ae2f-74d1-4fb2-8672-a3d4679e7948">


## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
