### PR TITLE
SDK version 3.8+

### DIFF
--- a/docs/sdk/flutter.mdx
+++ b/docs/sdk/flutter.mdx
@@ -92,7 +92,7 @@ On Android, add the Radar Android SDK to the `dependencies` section of your Andr
 
 ```kotlin
 dependencies {
-    implementation 'io.radar:sdk:3.8.12'
+    implementation 'io.radar:sdk:3.8.+'
 }
 ```
 

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -37,7 +37,7 @@ The SDK is small and typically adds less than 500 KB to your compiled app.
 Install [CocoaPods](https://cocoapods.org). If you don't have an existing `Podfile`, run `pod init` in your project directory. Add the following to your `Podfile`:
 
 ```swift
-pod 'RadarSDK', '~> 3.8'
+pod 'RadarSDK', '~> 3.8.11'
 ```
 
 Then, run `pod install`. You may also need to run `pod repo update`.
@@ -56,13 +56,13 @@ In Xcode, go to *File* > *Swift Packages* > *Add Package Dependency*. Enter `htt
 Install [Carthage](https://github.com/Carthage/Carthage). To include Radar as a `github` origin, add the following to your `Cartfile`:
 
 ```swift
-github "radarlabs/radar-sdk-ios" ~> 3.8
+github "radarlabs/radar-sdk-ios" ~> 3.8.11
 ```
 
 To include Radar as a `binary` origin, add the following to your `Cartfile`:
 
 ```swift
-binary "https://raw.githubusercontent.com/radarlabs/radar-sdk-ios/master/RadarSDK.json" ~> 3.8
+binary "https://raw.githubusercontent.com/radarlabs/radar-sdk-ios/master/RadarSDK.json" ~> 3.8.11
 ```
 
 Then, run `carthage update` and drag `Build/iOS/RadarSDK.framework` into the _Linked Frameworks and Libraries_ section of your target. Do not add the framework as an input to your `copy-frameworks` run script.

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -37,7 +37,7 @@ The SDK is small and typically adds less than 500 KB to your compiled app.
 Install [CocoaPods](https://cocoapods.org). If you don't have an existing `Podfile`, run `pod init` in your project directory. Add the following to your `Podfile`:
 
 ```swift
-pod 'RadarSDK', '~> 3.8.2'
+pod 'RadarSDK', '~> 3.8'
 ```
 
 Then, run `pod install`. You may also need to run `pod repo update`.
@@ -56,13 +56,13 @@ In Xcode, go to *File* > *Swift Packages* > *Add Package Dependency*. Enter `htt
 Install [Carthage](https://github.com/Carthage/Carthage). To include Radar as a `github` origin, add the following to your `Cartfile`:
 
 ```swift
-github "radarlabs/radar-sdk-ios" ~> 3.8.2
+github "radarlabs/radar-sdk-ios" ~> 3.8
 ```
 
 To include Radar as a `binary` origin, add the following to your `Cartfile`:
 
 ```swift
-binary "https://raw.githubusercontent.com/radarlabs/radar-sdk-ios/master/RadarSDK.json" ~> 3.8.2
+binary "https://raw.githubusercontent.com/radarlabs/radar-sdk-ios/master/RadarSDK.json" ~> 3.8
 ```
 
 Then, run `carthage update` and drag `Build/iOS/RadarSDK.framework` into the _Linked Frameworks and Libraries_ section of your target. Do not add the framework as an input to your `copy-frameworks` run script.


### PR DESCRIPTION
removed wherever we specify a patch version to avoid drift with the latest releases

latest iOS is 3.8.10 https://github.com/radarlabs/radar-sdk-ios/releases/tag/3.8.11
latest Android is 3.8.16 https://github.com/radarlabs/radar-sdk-android/releases/tag/3.8.17