### PR TITLE
Change min places search radius

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -793,7 +793,7 @@ Searches for places near a location, sorted by distance.
 - **`iataCode`** (string, optional): The 3-letter IATA code for the airport to search. If provided, no other parameters are required.
 - **`chainMetadata[key]`** (optional): Optional [chain metadata](/places#metadata) filters. Values may be of type string, boolean, or number. Type will be automatically inferred. For example, to match on `offers == true`, use `&chainMetadata[offers]=true`.
 - **`near`** (string, required): A location for the search. A string in the format `latitude,longitude`.
-- **`radius`** (number, optional): The radius to search, in meters. A number between 100 and 10000. Defaults to 1000.
+- **`radius`** (number, optional): The radius to search, in meters. A number between 1 and 10000. Defaults to 1000.
 - **`limit`** (number, optional): The max number of places to return. A number between 1 and 100. Defaults to 10.
 
 ###### Authentication level


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
Update min value for radius such that is aligns with server implementation

## Why?
Non-consistent with server implementation. As seen below, the true minimum is set at 1 m. [Link](https://github.com/radarlabs/server/blob/a2d621baccfb4ced2bcd7d39cb75d80f3f5a0a7f/server/endpoints/searchEndpoints.ts#L117)
<img width="329" alt="Screenshot 2023-11-28 at 11 39 26" src="https://github.com/radarlabs/documentation/assets/35515848/567b5484-3fc6-48bf-b772-ef01946c70d1">


## How?
<!--
  If you made a functional change (as opposed to just a content change):
    - How did you implement this change?
    - What decisions did you make?
-->

## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->

## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
