### PR TITLE
Add isTracking to documentation for all sdks

### DIFF
--- a/docs/sdk/android.mdx
+++ b/docs/sdk/android.mdx
@@ -402,6 +402,32 @@ To start tracking for geofencing, call:
   </TabItem>
 </Tabs>
 
+To determine whether or not tracking is active, call:
+
+<Tabs
+  groupId="android"
+  defaultValue="kotlin"
+  values={[
+    { label: 'Java', value: 'java' },
+    { label: 'Kotlin', value: 'kotlin' }
+  ]}
+>
+  <TabItem value="java">
+
+  ```java
+  Radar.isTracking();
+  ```
+
+  </TabItem>
+  <TabItem value="kotlin">
+
+  ```kotlin
+  Radar.isTracking()
+  ```
+
+  </TabItem>
+</Tabs>
+
 To stop tracking (e.g., when the user logs out), call:
 
 <Tabs

--- a/docs/sdk/android.mdx
+++ b/docs/sdk/android.mdx
@@ -402,7 +402,7 @@ To start tracking for geofencing, call:
   </TabItem>
 </Tabs>
 
-To determine whether or not tracking is active, call:
+To determine whether tracking has been started, call:
 
 <Tabs
   groupId="android"

--- a/docs/sdk/capacitor.mdx
+++ b/docs/sdk/capacitor.mdx
@@ -283,6 +283,12 @@ Radar.startTrackingCustom({
 });
 ```
 
+To determine whether or not tracking is active, call:
+
+```javascript
+Radar.isTracking();
+```
+
 To stop tracking the user's location in the background (e.g., when the user logs out), call:
 
 ```javascript

--- a/docs/sdk/capacitor.mdx
+++ b/docs/sdk/capacitor.mdx
@@ -283,7 +283,7 @@ Radar.startTrackingCustom({
 });
 ```
 
-To determine whether or not tracking is active, call:
+To determine whether tracking has been started, call:
 
 ```javascript
 Radar.isTracking();

--- a/docs/sdk/cordova.mdx
+++ b/docs/sdk/cordova.mdx
@@ -209,7 +209,7 @@ cordova.plugins.radar.startTrackingCustom({
 });
 ```
 
-To determine whether or not tracking is active, call:
+To determine whether tracking has been started, call:
 
 ```javascript
 cordova.plugins.radar.isTracking();

--- a/docs/sdk/cordova.mdx
+++ b/docs/sdk/cordova.mdx
@@ -209,6 +209,12 @@ cordova.plugins.radar.startTrackingCustom({
 });
 ```
 
+To determine whether or not tracking is active, call:
+
+```javascript
+cordova.plugins.radar.isTracking();
+```
+
 To stop tracking the user's location in the background (e.g., when the user logs out), call:
 
 ```javascript

--- a/docs/sdk/flutter.mdx
+++ b/docs/sdk/flutter.mdx
@@ -315,6 +315,13 @@ Radar.startTrackingCustom({
 });
 ```
 
+To determine whether or not tracking is active, call:
+
+```dart
+Radar.isTracking();
+```
+
+
 To stop tracking the user's location in the background (e.g., when the user logs out), call:
 
 ```dart

--- a/docs/sdk/flutter.mdx
+++ b/docs/sdk/flutter.mdx
@@ -315,7 +315,7 @@ Radar.startTrackingCustom({
 });
 ```
 
-To determine whether or not tracking is active, call:
+To determine whether tracking has been started, call:
 
 ```dart
 Radar.isTracking();

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -616,7 +616,7 @@ Radar.startTracking(trackingOptions: RadarTrackingOptions.presetResponsive)
   </TabItem>
 </Tabs>
 
-To determine whether or not tracking is active, call:
+To determine whether tracking has been started, call:
 
 <Tabs
   groupId="ios"

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -616,6 +616,32 @@ Radar.startTracking(trackingOptions: RadarTrackingOptions.presetResponsive)
   </TabItem>
 </Tabs>
 
+To determine whether or not tracking is active, call:
+
+<Tabs
+  groupId="ios"
+  defaultValue="swift"
+  values={[
+    { label: 'Swift', value: 'swift' },
+    { label: 'Objective-C', value: 'objc' }
+  ]}
+>
+  <TabItem value="swift">
+
+```swift
+Radar.isTracking()
+```
+
+  </TabItem>
+  <TabItem value="objc">
+
+```objc
+[Radar isTracking];
+```
+
+  </TabItem>
+</Tabs>
+
 To stop tracking (e.g., when the user logs out), call:
 
 <Tabs

--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -268,6 +268,12 @@ Radar.startTrackingCustom({
 });
 ```
 
+To determine whether or not tracking is active, call:
+
+```javascript
+Radar.isTracking();
+```
+
 To stop tracking the user's location in the background (e.g., when the user logs out), call:
 
 ```javascript

--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -268,7 +268,7 @@ Radar.startTrackingCustom({
 });
 ```
 
-To determine whether or not tracking is active, call:
+To determine whether tracking has been started, call:
 
 ```javascript
 Radar.isTracking();

--- a/docs/sdk/xamarin.mdx
+++ b/docs/sdk/xamarin.mdx
@@ -129,7 +129,7 @@ trackingOptions.Replay = RadarTrackingOptionsReplay.None;
 Radar.StartTracking(trackingOptions);
 ```
 
-To determine whether or not tracking is active, call:
+To determine whether tracking has been started, call:
 
 ```cs
 Radar.IsTracking();

--- a/docs/sdk/xamarin.mdx
+++ b/docs/sdk/xamarin.mdx
@@ -129,6 +129,12 @@ trackingOptions.Replay = RadarTrackingOptionsReplay.None;
 Radar.StartTracking(trackingOptions);
 ```
 
+To determine whether or not tracking is active, call:
+
+```cs
+Radar.IsTracking();
+```
+
 To stop tracking the user's location in the background (e.g., when the user logs out), call:
 
 ```cs


### PR DESCRIPTION
## What?
Adds missing `Radar.isTracking()` call and description to the documentation.
