### PR TITLE
Specify how to pass in empty near param in autocomplete

### DIFF
--- a/docs/sdk/flutter.mdx
+++ b/docs/sdk/flutter.mdx
@@ -485,7 +485,9 @@ var res = await Radar.ipGeocode((result) => {
 
 #### Search
 
-With the [autocomplete API](/api#autocomplete), autocomplete partial addresses and place names, sorted by relevance:
+With the [autocomplete API](/api#autocomplete), autocomplete partial addresses and place names, sorted by relevance.
+
+To perform an autocomplete without specifying a location, you can pass an empty map (`{}`) as the `near` parameter:
 
 ```dart
 var res = await Radar.autocomplete(


### PR DESCRIPTION
## What?
<!--
Per observations here https://linear.app/radarlabs/issue/MOB-74/dickeys-dollar18k-q4-maps-opp-is-in-active-stg-3-and-evaluating 

adding a note to Autocomplete Flutter docs to specify how to properly perform an autocomplete without specifying a `near` location.
-->

## Why?
<!--
Dickey's tried to pass in null and omit the `near` param and ran into an error - the empty map method outlined in the docs update does not cause the same error - adding to docs for clarity -->

## How?
<!--
Updated docs to specify how to omit passing in location to an autocomplete request
-->

## Screenshots (optional)
<!--
-->

## Anything Else? (optional)
<!--
-->
