### PR TITLE
fix curl example in api.mdx

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1121,7 +1121,7 @@ Publishable
 ###### Sample request
 
 ```bash
-curl "https://api.radar.io/v1/route/match?path=40.73421259605101,-73.98635368448336|40.73615136186456,-73.98534685613593|40.73616535996882,-73.98026652961276|40.73701616007588,-73.98238510730718&mode=car&roadAttributes=names, speedLimit, roadClass" \
+curl "https://api.radar.io/v1/route/match?path=40.73421259605101,-73.98635368448336|40.73615136186456,-73.98534685613593|40.73616535996882,-73.98026652961276|40.73701616007588,-73.98238510730718&mode=car&roadAttributes=names,speedLimit,roadClass" \
   -H "Authorization: prj_live_pk_..."
 ```
 


### PR DESCRIPTION
spaces after commas otherwise lead curl to report "curl: (3) URL rejected: Malformed input to a URL function"

actually, the API doesn't accept that string with spaces either -- it returns "roadAttributes: Invalid string array. Valid values: names, speedLimit, roadClass" if spaces are passed