### PR TITLE
add new fields to timezone docs

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -578,9 +578,12 @@ curl "https://api.radar.io/v1/geocode/reverse?coordinates=40.70390,-73.98670" \
       "county": "Kings County",
       "neighborhood": "DUMBO",
       "timezone": {
-        "name": "America/New_York",
+        "id": "America/New_York",
+        "name": "Eastern Daylight Time",
+        "code": "EDT",
         "currentTime": "2024-04-09T10:12:00-04:00",
-        "utcOffset": -14400
+        "utcOffset": -14400,
+        "dstOffset": 3600
       },
       "number": "20",
       "distance": 5,


### PR DESCRIPTION
Add `name`, `code`, and `dstOffset` to timezone example.