### PR TITLE
specify that static map locations are lat,lng

### DIFF
--- a/docs/maps/static-maps.mdx
+++ b/docs/maps/static-maps.mdx
@@ -49,6 +49,8 @@ Each markers parameter is made up of optional `markerStyle` sections, and one or
 markers=markerStyle|markerLocation1|markerLocation2|...
 ```
 
+*markerLocation* are specified in the following format `latitude,longitude` and are pipe separated.
+
 *markerStyle* are specified in the following format `optionName:optionValue` and are pipe separated. *markerStyle* have the following options:
 - `color` (string, optional): The color of the image specified as a hex in the following format `0xFFFFFF`. The default value if color is not specified is `0x000257`.
 - `size` (string, optional): By specifying `size:small` as an option, you can render a scaled down version of the marker.


### PR DESCRIPTION
## What?

add minimal specification for static maps `markerLocation` param i.e. how to pass marker coordinates

## Why?

the coordinates order is not specified

## Screenshots (optional)

<img width="1025" alt="image" src="https://github.com/radarlabs/documentation/assets/1017304/eeed8769-d72a-46a2-b952-077051627655">
