### PR TITLE
Remove the values from radius param for search/geofences

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -776,7 +776,7 @@ Searches for geofences near a location, sorted by distance.
 
 - **`near`** (string, required): A location for the search. A string in the format `latitude,longitude`.
 - **`limit`** (number, optional): The max number of geofences to return. A number between 1 and 1000. Defaults to 100.
-- **`radius`** (number, optional): Optional radius to search, in meters. A number between 100 and 10000.
+- **`radius`** (number, optional): Optional radius to search, in meters.
 - **`tags`** (string, optional): Optional tag filters. A string, comma-separated.
 - **`metadata[key]`** (string, optional): Optional metadata filters. Values may be of type string. Type will be automatically inferred. For example, to match on `offers == true`, use `&metadata[offers]=true`.
 - **`includeGeometry`** (boolean, optional): Include geofence geometries in the response. Defaults to `true`.


### PR DESCRIPTION
Remove the values from `radius` to better indicate it will only be used if provided.