### PR TITLE
Route Match response logic docs update - api.mdx

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1142,9 +1142,9 @@ curl "https://api.radar.io/v1/route/matrix?origins=40.78382,-73.97536&destinatio
 
 #### Route match
 
-Snaps points collected along a route to roads that were most likely traveled on. Returns the matched path and road information.
+Snaps points collected along a route to roads that were most likely traveled on. Returns the matched path and road information, omitting points with invalid or impossible distances between them.
 
-For best results, the sample rate should be less than 10 seconds between points.
+For best results, the sample rate should be less than 10 seconds between points. 
 
 ###### Definitions
 


### PR DESCRIPTION
Clarifies that points with impossible distances between them will not be returned in responses. 

Stemming from a customer who was confused by this behavior. 

https://linear.app/radarlabs/issue/MAPS-1091/route-matching-issues

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
<!--
  Please explain what problem your pull request is trying to solve.
  Are there any linked issues?
-->

Clarifies that points with impossible distances between them will not be returned in responses. 

Stemming from a customer who was confused by this behavior. 

https://linear.app/radarlabs/issue/MAPS-1091/route-matching-issues

## Why?
<!--
  Explain the **motivation** for making this change.
-->

Clarifies that all points passed in are not expected to return 100% of the time. 

## How?
<!--
  If you made a functional change (as opposed to just a content change):
    - How did you implement this change?
    - What decisions did you make?
-->

Docs update

## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->

## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
