### PR TITLE
Route match response logic updates api.mdx

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1142,7 +1142,7 @@ curl "https://api.radar.io/v1/route/matrix?origins=40.78382,-73.97536&destinatio
 
 #### Route match
 
-Snaps points collected along a route to roads that were most likely traveled on. Returns the matched path and road information.
+Snaps points collected along a route to roads that were most likely traveled on. Returns the matched path and road information, omitting points with invalid or impossible distances between them.
 
 For best results, the sample rate should be less than 10 seconds between points.
 
@@ -1166,6 +1166,7 @@ For best results, the sample rate should be less than 10 seconds between points.
     - `unclassified`
     - `residential`
     - `service_other`
+  - Routes that match to roads with `roadClass` values of `unclassified` or `service_other` (road types that do not have a formal speed limit) will return a `speedLimit` value of `-1`
 - **`units`** (string, optional): The distance and speed units. A string, `metric` or `imperial`. Defaults to `imperial` if not provided.
 - **`geometry`** (string, optional): The format of the `geometry` in the response.  Valid values are `linestring`, `polyline5` and `polyline6`. `linestring` returns a GeoJSON `LineString`, `polyline5` returns a polyline with 5 decimal places of precision (compatible with other mapping providers) and `polyline6` returns a polyline with 6 decimal places of precision. Defaults to `polyline6` if not provided.
 


### PR DESCRIPTION
clarifies that Route Match will not return all indices if there are impossible distances between points, clarifies the -1 speedLimit logic

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
<!--
  Please explain what problem your pull request is trying to solve.
  Are there any linked issues?
-->

Addresses questions from Innovative-E regarding when Radar doesn't return all indices in our Route match response - also clarifies when we return -1 as speedLimit

https://linear.app/radarlabs/issue/MAPS-1091/route-matching-issues 

## Why?
<!--
  Explain the **motivation** for making this change.
-->

Document Route Match response behavior based on latest changes 

## How?
<!--
  If you made a functional change (as opposed to just a content change):
    - How did you implement this change?
    - What decisions did you make?
-->

## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->

## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
