### PR TITLE
add missing publishable api key

### DIFF
--- a/docs/maps/static-maps.mdx
+++ b/docs/maps/static-maps.mdx
@@ -38,6 +38,7 @@ Static Map images can be used inline with HTML `<img>` tags by setting the `src`
 | `style` | `radar-default-v1` | `radar-default-v1`, `radar-light-v1`, `radar-dark-v1` | The style of the map. See [map styles](https://radar.com/documentation/maps/maps#styles) for more details. |
 | `markers` | none | string | For rendering markers on the map. See [markers](#markers) for more details. |
 | `path` | none | string | For rendering paths on the map. See [paths](#paths) for more details. |
+| `publishableKey` | none (required) | string | Your Radar publishable API key. |
 </div>
 
 ### Markers

--- a/src/components/StaticMap.jsx
+++ b/src/components/StaticMap.jsx
@@ -5,7 +5,8 @@ const PUBLISHABLE_KEY = 'org_test_pk_7e1e22718af02cb9ed4a01233556999c2c02c947'; 
 
 const StaticMap = ({ query, alt, imgTag, hideSnippet }) => {
   const url = `https://api.radar.io/maps/static?${query}`;
-  const img = `<img src="${url}" alt="${alt}" />`;
+  const urlForCodeBlock = `${url}&publishableKey=prj_live_pk_...`;
+  const img = `<img src="${urlForCodeBlock}" alt="${alt}" />`;
   const language = imgTag ? 'html' : 'text';
 
   const showSnippet = !Boolean(hideSnippet);
@@ -14,7 +15,7 @@ const StaticMap = ({ query, alt, imgTag, hideSnippet }) => {
     <div>
       { showSnippet &&
         <CodeBlock className={language}>
-          { imgTag ? img : url }
+          { imgTag ? img : urlForCodeBlock }
         </CodeBlock>
       }
       <img src={`${url}&publishableKey=${PUBLISHABLE_KEY}`} alt={alt} />


### PR DESCRIPTION
[Static Maps docs](https://radar.com/documentation/maps/static-maps) are missing info on `publishableKey` in the list of parameters and most examples that use the new `<StaticMap>` component

This adds that back:

<img width="990" alt="image" src="https://github.com/radarlabs/documentation/assets/1017304/126b0116-a506-477f-a8b0-d6a89cf3e58d">

<img width="377" alt="image" src="https://github.com/radarlabs/documentation/assets/1017304/4c98c84f-9354-4183-84d7-2594baa21e5c">
