### PR TITLE
iOS trips fg service description update

### DIFF
--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -696,9 +696,10 @@ You only need to call these methods once, as these settings will be persisted ac
 For trips, we recommend using `RadarTrackingOptions.presetContinuous`. This preset tells the SDK to send location updates to the server every 30 seconds, regardless of whether the device is moving.
 
 <Alert alertType="info">
-  By default, this preset shows the flashing blue status bar while tracking. If
-  the flashing blue status bar is shown, only foreground permissions are
+  By default, this preset shows the flashing blue status bar (for devices without the dynamic island) or blue location indicator (for devices with the dynamic island) while tracking. If
+  the flashing blue status bar or blue location indicator is shown, only foreground permissions are
   required for tracking.
+
 </Alert>
 
 Tracking for the duration of a trip is started or updated by including tracking options in the `startTrip` call:


### PR DESCRIPTION
adds dynamic island description to location indicator note in trips docs

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?

adds dynamic island description to location indicator note in trips docs


## Why?
includes newest fg service location indicator experience 

## How?
clarified phrasing 

## Screenshots (optional)


## Anything Else? (optional)
from slack discussion here: https://radarlabs.slack.com/archives/C06V789S55F/p1721167958241539 