### PR TITLE
Added 408: Request Timeout Response Code

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -36,6 +36,7 @@ The API uses standard HTTP response codes.
 - **`402`**: Payment required (organization disabled or usage exceeded)
 - **`403`**: Forbidden (insufficient permissions)
 - **`404`**: Not found
+- **`408`**: Request Timeout
 - **`409`**: Conflict
 - **`429`**: Too many requests (rate limit exceeded, no state change, or selective throttling)
 - **`451`**: Unavailable for legal reasons (country blocklisted)


### PR DESCRIPTION
Added 408: Request Timeout Response Code (prompted by response codes seen in FiveBelow dashboard)

<!--
  Adding line for 408 response code in the documentation.
-->

## What?
<!--
  More user context.
-->

## Why?
<!--
  FiveBelow customer call, inquiry about response codes and no docs to answer.
-->

## How?
<!--
  If you made a functional change (as opposed to just a content change):
    - How did you implement this change?
    - What decisions did you make?
-->

## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->

## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
