### PR TITLE
show live api keys when they are available

### DIFF
--- a/docs/fraud.mdx
+++ b/docs/fraud.mdx
@@ -138,7 +138,7 @@ To support the `sharing` flag on Android, pass `fraud = true` to `Radar.initiali
 ```kotlin
 Radar.initialize(
   context = this,
-  publishableKey = "prj_test_pk...",
+  publishableKey = "prj_test_pk_...",
   fraud = true
 )
 ```

--- a/docs/sdk/android.mdx
+++ b/docs/sdk/android.mdx
@@ -89,7 +89,7 @@ Use your `Test Publishable` key for testing and non-production environments. Use
       public void onCreate() {
           super.onCreate();
 
-          Radar.initialize(this, "prj_test_pk...");
+          Radar.initialize(this, "prj_test_pk_...");
       }
 
   }
@@ -106,7 +106,7 @@ Use your `Test Publishable` key for testing and non-production environments. Use
       override fun onCreate() {
           super.onCreate()
 
-          Radar.initialize(this, "prj_test_pk...")
+          Radar.initialize(this, "prj_test_pk_...")
       }
 
   }
@@ -726,7 +726,7 @@ To listen for events, location updates, and errors client-side, create a class t
           super.onCreate();
 
           MyRadarReceiver receiver = new MyRadarReceiver();
-          Radar.initialize(this, "prj_test_pk...", receiver, Radar.RadarLocationServicesProvider.GOOGLE);
+          Radar.initialize(this, "prj_test_pk_...", receiver, Radar.RadarLocationServicesProvider.GOOGLE);
       }
 
   }
@@ -744,7 +744,7 @@ To listen for events, location updates, and errors client-side, create a class t
           super.onCreate()
 
           val receiver = MyRadarReceiver()
-          Radar.initialize(this, "prj_test_pk...", receiver, Radar.RadarLocationServicesProvider.GOOGLE)
+          Radar.initialize(this, "prj_test_pk_...", receiver, Radar.RadarLocationServicesProvider.GOOGLE)
       }
 
   }

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -882,7 +882,7 @@ import RadarSDK
 class AppDelegate: UIResponder, UIApplicationDelegate, RadarDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        Radar.initialize(publishableKey: "prj_test_pk...")
+        Radar.initialize(publishableKey: "prj_test_pk_...")
         Radar.setDelegate(self)
 
         return true
@@ -1155,7 +1155,7 @@ import RadarSDK
 class AppDelegate: UIResponder, UIApplicationDelegate, RadarDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        Radar.initialize(publishableKey: "prj_test_pk...")
+        Radar.initialize(publishableKey: "prj_test_pk_...")
         Radar.setDelegate(self)
 
         return true

--- a/docs/tutorials/building-a-delivery-tracking-app.mdx
+++ b/docs/tutorials/building-a-delivery-tracking-app.mdx
@@ -71,7 +71,7 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     override init() {
 
         super.init()
-        Radar.initialize(publishableKey: "prj_test_pk...")
+        Radar.initialize(publishableKey: "prj_test_pk_...")
 
         self.locationManager.delegate = self
     }

--- a/docs/tutorials/building-an-on-premise-mode.mdx
+++ b/docs/tutorials/building-an-on-premise-mode.mdx
@@ -67,7 +67,7 @@ class MyApplication : Application() {
   override fun onCreate() {
     super.onCreate()
 
-    Radar.initialize(this, "prj_test_pk...")
+    Radar.initialize(this, "prj_test_pk_...")
     Radar.setUserId("foo")
   }
 

--- a/docs/tutorials/displaying-radar-maps-on-ios.mdx
+++ b/docs/tutorials/displaying-radar-maps-on-ios.mdx
@@ -23,7 +23,7 @@ struct MapView: UIViewRepresentable {
         // create a map
 
         let style = "radar-default-v1"
-        let publishableKey = "prj_live_pk..."
+        let publishableKey = "prj_live_pk_..."
         let styleURL = URL(string: "https://api.radar.io/maps/styles/\(style)?publishableKey=\(publishableKey)")
 
         let mapView = MLNMapView(frame: .zero, styleURL: styleURL)

--- a/docs/tutorials/logging-and-analyzing-where-conversions-occur.md
+++ b/docs/tutorials/logging-and-analyzing-where-conversions-occur.md
@@ -74,7 +74,7 @@ When your app starts, in application `onCreate()`, initialize the SDK with your 
       override fun onCreate() {
           super.onCreate()
 
-          Radar.initialize(this, "prj_test_pk...")
+          Radar.initialize(this, "prj_test_pk_...")
       }
 
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@docusaurus/theme-search-algolia": "^2.0.0-beta.6",
         "@mdx-js/react": "^1.6.21",
         "@svgr/webpack": "^5.5.0",
+        "axios": "^1.7.8",
         "clsx": "^1.1.1",
         "cspell": "^6.31.2",
         "file-loader": "^6.2.0",
@@ -3912,6 +3913,11 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -3958,11 +3964,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.8.tgz",
+      "integrity": "sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==",
       "dependencies": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -5014,6 +5022,17 @@
       "integrity": "sha512-ZI9jvcLDxqwaXEixOhArm3r7ReIivsXkpbyEWyeOhzz1QS0iSgBPnWvEqvIQtYyamGCYA88gFhmUrs9hrrQ0pg==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/comma-separated-tokens": {
@@ -6076,6 +6095,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -7087,9 +7114,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
-      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
@@ -7294,6 +7321,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -11866,6 +11906,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -15386,6 +15431,14 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/wait-on/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/watchpack": {
@@ -19581,6 +19634,11 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -19605,11 +19663,13 @@
       }
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.8.tgz",
+      "integrity": "sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "babel-loader": {
@@ -20417,6 +20477,14 @@
       "resolved": "https://registry.npmjs.org/combine-promises/-/combine-promises-1.1.0.tgz",
       "integrity": "sha512-ZI9jvcLDxqwaXEixOhArm3r7ReIivsXkpbyEWyeOhzz1QS0iSgBPnWvEqvIQtYyamGCYA88gFhmUrs9hrrQ0pg=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "comma-separated-tokens": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
@@ -21173,6 +21241,11 @@
         "rimraf": "^3.0.2",
         "slash": "^3.0.0"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -21991,9 +22064,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
-      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg=="
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -22148,6 +22221,16 @@
             "repeat-string": "^1.6.1"
           }
         }
+      }
+    },
+    "form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -25442,6 +25525,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -28075,6 +28163,16 @@
         "lodash": "^4.17.21",
         "minimist": "^1.2.5",
         "rxjs": "^6.6.3"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        }
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@docusaurus/theme-search-algolia": "^2.0.0-beta.6",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
+    "axios": "^1.7.8",
     "clsx": "^1.1.1",
     "cspell": "^6.31.2",
     "file-loader": "^6.2.0",

--- a/src/theme/CodeBlock/LoggedInApiKey.js
+++ b/src/theme/CodeBlock/LoggedInApiKey.js
@@ -5,6 +5,11 @@ class LoggedInApiKey {
   testPublicKey = null;
 
   attemptToFetchKeys() {
+    // components are prerendered on the server -- obviously
+    // don't run there.
+    if(typeof window === 'undefined') {
+      return;
+    }
     if(!window.localStorage) {
       return;
     }

--- a/src/theme/CodeBlock/LoggedInApiKey.js
+++ b/src/theme/CodeBlock/LoggedInApiKey.js
@@ -1,0 +1,79 @@
+import axios from 'axios';
+
+class LoggedInApiKey {
+  // only care/fetch the test public key
+  testPublicKey = null;
+
+  attemptToFetchKeys() {
+    if(!window.localStorage) {
+      return;
+    }
+    let redux = window.localStorage.redux;
+    if(!redux) {
+      return;
+    }
+    try {
+      redux = JSON.parse(redux)
+    } catch(e) {
+      return
+    }
+    if(!redux.session) {
+      return;
+    }
+    const apiHost = redux.session.apiHost;
+    if(!apiHost) {
+      return;
+    }
+    const headers = {
+      'Content-Type': 'application/json',
+      'Authorization': redux.session.token,
+      'X-Radar-Live': false,
+    };
+    const options = {
+      url: `${apiHost}/app/organization/keys`,
+      method: 'GET',
+      headers
+    };
+    const that = this;
+    axios(options).then(response => {
+      if(response.data && response.data.keys && response.data.keys.length === 1) {
+        const testKeys = response.data.keys[0].keys.filter(key => key.live === false);
+        if(testKeys.length) {
+          that.testPublicKey = testKeys.filter(key => key.secret === false)[0].key;
+        }
+      }
+    })
+  }
+
+  getTestKeys() {
+    // return a promise that will check whether the keys
+    // are ready and return them then, and otherwise will set a set interval
+    // until they are ready
+    return new Promise((resolve, reject) => {
+      if(this.testPublicKey) {
+        resolve({
+          testPublicKey: this.testPublicKey
+        })
+      } else {
+        const interval = setInterval(() => {
+          if(this.testPublicKey) {
+            clearInterval(interval);
+            resolve({
+              testPublicKey: this.testPublicKey
+            })
+          }
+        }, 500)
+        // don't have a bunch of intervals running forever
+        // if the load doesn't work
+        setTimeout(() => {
+          clearInterval(interval);
+          reject('Timed out fetching keys')
+        }, 5000);
+      }
+    })
+  }
+}
+
+const apiKeyFetcher = new LoggedInApiKey()
+apiKeyFetcher.attemptToFetchKeys()
+export { apiKeyFetcher };


### PR DESCRIPTION
## what is this?

this PR checks if the user is logged into the dashboard (i.e. has an active session), fetch the user's api keys using that session token, and swaps in the real api key into the example code blocks

- this replaces all `prj_live_pk_...` and `prj_test_pk_...` with the user's public api test keys
- secret keys i.e. `_sk_...` are not replaced

---

- to test locally:
  - go to prod i.e. radar.com/dashboard
  - make a copy of `localStorage.redux` using the devtools
  - go to the docs running locally at http://localhost:3000
  - run `localStorage.setItem("redux", "...")` with the contents of the redux session payload
  - reload the docs - the public api keys should be replaced in all code blocks as in the screenshot below

![Screenshot 2024-11-25 at 6 07 30 PM](https://github.com/user-attachments/assets/42fd4e5c-ddaf-48bb-b985-7e009c4df109)

---

per [this conversation](https://radarlabs.slack.com/archives/C04RPS3PF9N/p1732582689827689) in Slack, note that this solution will only work while we haven't migrated docs to `docs.radar.com`

when that happens, one of the proposed solutions would be to only set the test publishable key (i.e. not the whole redux/session token) as a cookie on the `docs.radar.com` subdomain (from the `radar.com` domain), and then for the docs to retrieve that cookie and show that key.