### PR TITLE
fix curl example

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -774,7 +774,7 @@ Publishable
 ###### Sample request
 
 ```bash
-curl "https://api.radar.io/v1/search/geofences?tags=store&metadata[offers]=true&near=40.783826,-73.975363&radius=1000&limit=10" \
+curl "https://api.radar.io/v1/search/geofences?tags=store&metadata%5Boffers%5D=true&near=40.783826,-73.975363&radius=1000&limit=10" \
   -H "Authorization: prj_live_pk_..."
 ```
 


### PR DESCRIPTION
fixes "bad range in URL position" curl error as the `[]` are not url encoded