### PR TITLE
Add p50 & p95 latencies to docs

### DIFF
--- a/docs/faqs.mdx
+++ b/docs/faqs.mdx
@@ -63,8 +63,37 @@ With just foreground location permissions, you can leverage the [background loca
 Each listener can support different use cases and exposes different data to take actions. The client location listener (`onClientLocationUpdated` on Android, `didUpdateClientLocation` on iOS) is fired whenever the Radar SDK receives a location update from the device. It can be used to collect a stream of location updates before they hit Radar servers. The location updated listener (`onLocationUpdated` on Android, `didUpdateLocation` on iOS) delivers location updates processed by Radar servers and will return refreshed user context. This listener can be used to deliver in-app experiences based on user context, including when `Radar.trackOnce()` is called on application launch. The Radar events listener (`didReceiveEvents` on Android and iOS) can be used to listen for Radar events and trigger workflows.
 
 ### What is the latency of Radar APIs?
+See tables below for p50 & p95 latencies. Note that the /route/matrix API increases in latency as additional origin or destination points are added, or as the distance between points increases. 
 
-Radar APIs have a p50 latency of 50ms and a p90 of 150ms.  The `/route/matrix` API increases in latency as additional `origin` or `destination` points are added, or as the distance between points increases.
+#### p50 latencies per endpoint
+
+| Endpoint                          | Latency (ms)     |
+|-----------------------------------|-----------------|
+| /v1/addresses/validate GET       | 250  |
+| /v1/route/optimize GET           | 250   |
+| /v1/geocode/forward GET          | 100    |
+| /v1/search/autocomplete GET      | 100   |
+| /v1/route/directions GET         | 50  |
+| /v1/route/match POST             | 50   |
+| /v1/route/distance GET           | 50    |
+| /v1/geocode/reverse GET          | 50  |
+| /v1/route/matrix GET             | 50  |
+| /v1/geocode/ip GET               | 10   |
+
+#### p95 latencies per endpoint
+
+| Endpoint                          | Latency (ms)     |
+|-----------------------------------|-----------------|
+| /v1/addresses/validate GET       | 700   |
+| /v1/geocode/forward GET          | 500   |
+| /v1/route/match POST             | 500     |
+| /v1/search/autocomplete GET      | 300   |
+| /v1/route/optimize GET           | 300   |
+| /v1/route/distance GET           | 200  |
+| /v1/route/directions GET         | 200   |
+| /v1/route/matrix GET             | 100   |
+| /v1/geocode/reverse GET          | 100   |
+| /v1/geocode/ip GET               | 40  |
 
 ### How often are usage statistics recalculated?
 


### PR DESCRIPTION
@tjulien @gianiek what do we think about exposing the latencies per endpoint in our docs? @tjulien I rounded down across the board based on the metrics you had shared. Few of the p95's that stick out: 

- Autocomplete (shared: 486ms, docs 300ms) - Took a look at a few of our accounts that've been live in production (Michaels, VSCO, Bevmo) etc and noticed ~250-400 so I think 300ms is a valid avg to share. 
- Forward (shared 728ms, docs 500) - This one was pretty variable across our accounts that are live, 500 seemed like a fair # to share. 
- Validate (shared: 752ms, docs 700) - This one just seems like a high number to share but haven't heard customers bring that up as most other services have a fairly high latency as well. 

Pros of sharing latency per endpoint: 
- SE's get this question all the time, esp about geocoding & autocomplete. As we ramp-up more A/B tests, it would be good to point to our docs and set expectations. 
- F/U q's that SE's usually get are related to optimization techniques to decrease latency, setting expectations can help with this. 

Cons: 
- We've heard that for geocoding/autocomplete, our latencies can be a bit higher than what customers are used to with Google/Loqate etc so might come off as a negative. 



<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## What?
<!--
  Please explain what problem your pull request is trying to solve.
  Are there any linked issues?
-->

## Why?
<!--
  Explain the **motivation** for making this change.
-->

## How?
<!--
  If you made a functional change (as opposed to just a content change):
    - How did you implement this change?
    - What decisions did you make?
-->

## Screenshots (optional)
<!--
  If you made a UI change, please include any screenshots/videos!
-->

## Anything Else? (optional)
<!--
  Any other considerations (e.g. anti-goals, not yet implemented) that you want to call out for reviewers?
-->
