### PR TITLE
Remove base url

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -80,7 +80,7 @@ This endpoint is stateful. For anonymous or stateless context, call the [context
 - **`userId`** (string, optional): A stable unique ID for the user. Used with `deviceId` to identify logged in users. Not required for logged out users.
 - **`latitude`** (number, required): The user's current latitude. A number between -90 and 90.
 - **`longitude`** (number, required): The user's current longitude. A number between -180 and 180.
-- **`accuracy`** (number, required): The accuracy of the user's current latitude and longitude, in meters. A number greater than 0. Used when evaluating the [confidence](/documentation/geofences#confidence-and-accuracy) of geofence events.
+- **`accuracy`** (number, required): The accuracy of the user's current latitude and longitude, in meters. A number greater than 0. Used when evaluating the [confidence]/geofences#confidence-and-accuracy) of geofence events.
 - **`foreground`** (boolean, optional): `true` if the client is in the foreground, `false` if the client is in the background.
 - **`stopped`** (boolean, optional): `true` if the user is stopped, `false` if the user is moving.
 - **`description`** (string, optional): An optional description for the user, displayed in the dashboard.
@@ -2462,8 +2462,8 @@ A user represents a user tracked in your project. Users can be referenced by Rad
 - **`state`** (dictionary): When [Regions](/regions) is enabled, the user's current state. US-only.
 - **`dma`** (dictionary): When [Regions](/regions) is enabled, the user's current DMA (market area). US-only.
 - **`postalCode`** (dictionary): When [Regions](/regions) is enabled, the user's current postal code. US-only.
-- **`beacons`** (array): When [beacons](/documentation/beacons) have been created, an array of the user's current beacons.
-- **`fraud`** (object): When [Fraud](/documentation/fraud) is enabled, indicates whether the user passed fraud checks.
+- **`beacons`** (array): When [beacons]/beacons) have been created, an array of the user's current beacons.
+- **`fraud`** (object): When [Fraud]/fraud) is enabled, indicates whether the user passed fraud checks.
 
 ###### Sample object
 
@@ -2731,8 +2731,8 @@ A trip is a sequence of location updates with metadata and a unique ID, optional
 - **`approachingThreshold`** (number): For trips with a destination, the [trip approaching threshold](/trip-tracking#trip-events) setting for the trip (in minutes). Overrides the geofence-level and project-level trip approaching threshold settings.
 - **`createdAt`** (datetime): The datetime when the trip was started.
 - **`updatedAt`** (datetime): The datetime when the trip's location was last updated.
-- **`scheduledArrivalAt`** (datetime): Required for the [Olo order firing integration](/documentation/integrations/olo#order-firing), the backstop datetime when the device on the trip is expected to arrive. The order will be fired `approachingThreshold` minutes before `scheduledArrivalAt`.
-- **`orderFiredAt`** (datetime): From the [Olo integration](/documentation/integrations/olo), the datetime when the order associated with the trip was fired.
+- **`scheduledArrivalAt`** (datetime): Required for the [Olo order firing integration]/integrations/olo#order-firing), the backstop datetime when the device on the trip is expected to arrive. The order will be fired `approachingThreshold` minutes before `scheduledArrivalAt`.
+- **`orderFiredAt`** (datetime): From the [Olo integration]/integrations/olo), the datetime when the order associated with the trip was fired.
 - **`arrivedAt`** (datetime): For trips with a destination, the datetime when the user arrived at the trip destination (entered the destination geofence).
 - **`completedAt`** (datetime): The datetime when the trip was stopped.
 - **`status`** (string): The status of the trip, one of `pending`, `started`, `approaching`, `arrived`, `expired`, `completed`, or `canceled`.
@@ -2995,7 +2995,7 @@ Creates a new trip.
 - **`userId`** (string, optional): The external ID of the [user](/api#users) for which the trip is being tracked.
 - **`mode`** (string, optional): The [travel mode](/api#route-distance) for the trip. A string, one of `foot`, `bike`, and `car`. Defaults to `car`.
 - **`approachingThreshold`** (number, optional): For trips with a destination, the [trip approaching threshold](/trip-tracking#trip-events) setting for the trip (in minutes). Overrides the geofence-level and project-level trip approaching threshold settings.
-- **`scheduledArrivalAt`** (datetime): Required for the [Olo order firing integration](/documentation/integrations/olo#order-firing), the backstop datetime when the device on the trip is expected to arrive. The order will be fired `approachingThreshold` minutes before `scheduledArrivalAt`.
+- **`scheduledArrivalAt`** (datetime): Required for the [Olo order firing integration]/integrations/olo#order-firing), the backstop datetime when the device on the trip is expected to arrive. The order will be fired `approachingThreshold` minutes before `scheduledArrivalAt`.
 - **`metadata`** (dictionary, optional): An optional set of custom key-value pairs for the trip.
 
 ###### Default rate limit
@@ -3076,8 +3076,8 @@ On iOS and Android, use the [SDK](/sdk) to update trips.
 - **`mode`** (string, optional): The [travel mode](/api#route-distance) for the trip. A string, one of `foot`, `bike`, and `car`.
 - **`destinationGeofenceTag`** (string, optional): For trips with a destination, the tag of the destination geofence.
 - **`destinationGeofenceExternalId`** (string, optional): For trips with a destination, the external ID of the destination geofence.
-- **`approachingThreshold`** (number, optional): For trips with a destination, the [trip approaching threshold](/documentation/trip-tracking#trip-events) setting for the trip (in minutes). Overrides the geofence-level and project-level trip approaching threshold settings.
-- **`scheduledArrivalAt`** (datetime, optional): Required for the [Olo order firing integration](/documentation/integrations/olo#order-firing), the backstop datetime when the device on the trip is expected to arrive. The order will be fired `approachingThreshold` minutes before `scheduledArrivalAt`.
+- **`approachingThreshold`** (number, optional): For trips with a destination, the [trip approaching threshold]/trip-tracking#trip-events) setting for the trip (in minutes). Overrides the geofence-level and project-level trip approaching threshold settings.
+- **`scheduledArrivalAt`** (datetime, optional): Required for the [Olo order firing integration]/integrations/olo#order-firing), the backstop datetime when the device on the trip is expected to arrive. The order will be fired `approachingThreshold` minutes before `scheduledArrivalAt`.
 - **`metadata`** (dictionary, optional): An optional set of custom key-value pairs for the trip.
 
 ###### Default rate limit

--- a/docs/beacons.mdx
+++ b/docs/beacons.mdx
@@ -60,7 +60,7 @@ First, [sign up](https://radar.com/signup) for Radar and get an API key.
 
 Then, [create beacons](#create-beacons).
 
-From there, [integrate the SDK](/documentation/sdk) and call `Radar.trackOnce()` with `beacons = true` or `Radar.startTracking()` with `trackingOptions.beacons = true`, depending on your use case. Radar will generate an entry event on the first location update within range of a beacon.
+From there, [integrate the SDK]/sdk) and call `Radar.trackOnce()` with `beacons = true` or `Radar.startTracking()` with `trackingOptions.beacons = true`, depending on your use case. Radar will generate an entry event on the first location update within range of a beacon.
 
 ## How it works
 

--- a/docs/fraud.mdx
+++ b/docs/fraud.mdx
@@ -17,7 +17,7 @@ import InlineTabItem from "../src/components/InlineTabItem";
 
 With Fraud, you can detect GPS spoofing, proxy and VPN usage, device tampering, and much more.
 
-Along with [Regions](/documentation/regions), you can also detect a user's country and state and mark specific regions as allowed or blocked to comply with regulations.
+Along with [Regions]/regions), you can also detect a user's country and state and mark specific regions as allowed or blocked to comply with regulations.
 
 <img
   className="hero-image--small"
@@ -71,11 +71,11 @@ First, [sign up](https://radar.com/signup) for Radar and get an API key.
 
 Then, enable Fraud on the [Settings page](https://radar.com/dashboard/settings#fraud-settings).
 
-From there, [integrate the SDK](/documentation/sdk), complete the steps below, and call `Radar.trackVerified()` or `Radar.startTrackingVerified()`. Radar will perform fraud and jurisdiction checks as described below.
+From there, [integrate the SDK]/sdk), complete the steps below, and call `Radar.trackVerified()` or `Radar.startTrackingVerified()`. Radar will perform fraud and jurisdiction checks as described below.
 
 ## How it works
 
-You can call `Radar.trackOnce()` to accurately detect a user's current [geofences](/documentation/geofences), current [place](/documentation/places), or current [country and state](/documentation/regions).
+You can call `Radar.trackOnce()` to accurately detect a user's current [geofences]/geofences), current [place]/places), or current [country and state]/regions).
 
 However, users can spoof a device's location. For example, a gaming app user may spoof their location to access sports betting features only available in specific states. Or, a retail app user may spoof their location to access offers only available inside a store geofence.
 
@@ -113,7 +113,7 @@ If a user is blocked, `user.fraud.blocked = true` and `user.fraud.passed = false
 
 ## Allowed states and countries
 
-With [Regions](/documentation/regions), you can mark specific countries or states as allowed or blocked to comply with regulations. For example, a sportsbook or daily fantasy sports app may only be allowed to operate in specific US states.
+With [Regions]/regions), you can mark specific countries or states as allowed or blocked to comply with regulations. For example, a sportsbook or daily fantasy sports app may only be allowed to operate in specific US states.
 
 Radar exposes your settings in `user.country.allowed` and `user.state.allowed`.
 

--- a/docs/geofences.mdx
+++ b/docs/geofences.mdx
@@ -48,7 +48,7 @@ First, [sign up](https://radar.com/signup) for Radar and get an API key.
 
 Then, [create geofences](#create-a-geofence).
 
-From there, [integrate the SDK](/documentation/sdk) and call `Radar.trackOnce()` or `Radar.startTracking()`, depending on your use case. Radar will generate an entry event on the first location update inside of a geofence.
+From there, [integrate the SDK]/sdk) and call `Radar.trackOnce()` or `Radar.startTracking()`, depending on your use case. Radar will generate an entry event on the first location update inside of a geofence.
 
 ## How it works
 

--- a/docs/geofencing/overview.mdx
+++ b/docs/geofencing/overview.mdx
@@ -11,7 +11,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Radar's Geofencing Platform is the industry-leading geofencing and location tracking platform, including geofencing, place visit detection, trip tracking, fraud detection, and analytics.
 
-Together with our [Maps Platform](/documentation/maps/overview), Radar provides full-stack location infrastructure for any product or service. We power location-based experiences for [enterprises and startups](https://radar.com/customers) across hundreds of millions of devices worldwide.
+Together with our [Maps Platform]/maps/overview), Radar provides full-stack location infrastructure for any product or service. We power location-based experiences for [enterprises and startups](https://radar.com/customers) across hundreds of millions of devices worldwide.
 
 ## Features
 

--- a/docs/geofencing/testing.mdx
+++ b/docs/geofencing/testing.mdx
@@ -75,7 +75,7 @@ As the Radar SDK collects location updates and sends them to the server, it will
 
 ### Multiple Radar users have the same user ID or device ID
 
-Learn more about when Radar creates new user records [here](/documentation/faqs#what-is-a-unique-user-when-does-radar-create-a-new-user-record).
+Learn more about when Radar creates new user records [here]/faqs#what-is-a-unique-user-when-does-radar-create-a-new-user-record).
 
 ### Rate limit errors are occurring when tracking location
 

--- a/docs/maps/autocomplete.mdx
+++ b/docs/maps/autocomplete.mdx
@@ -26,7 +26,7 @@ Available options include:
 | `container` | `autocomplete` | string \| HTMLElement | The container to render the autocomplete into. You can specify an `id` of an HTML element or a DOM element. If an `<input>` is provided as a container, the style of the input will not be modified. | Web |
 | `width` | `400` | number \| string | The width of the input, a number (in pixels) or any valid CSS width. | Web |
 | `maxHeight` | `null` | number \| string | The max height of the results list, a number (in pixels) or any valid CSS height. | Web |
-| `near` | `null` | string \| Location | The location to search near, in the format `"latitude,longitude"` or `{ latitude, longitude }`. If not specified, the search will automatically be biased based on the client's [IP geolocation](/documentation/api#ip-geocode). | Web, React Native |
+| `near` | `null` | string \| Location | The location to search near, in the format `"latitude,longitude"` or `{ latitude, longitude }`. If not specified, the search will automatically be biased based on the client's [IP geolocation]/api#ip-geocode). | Web, React Native |
 | `debounceMS` | `200` | number | The number of milliseconds to wait after typing is complete to refresh the results list. | Web, React Native |
 | `minCharacters` | `3` | number | The minimum number of characters that need to be typed before fetching results. | Web, React Native |
 | `limit` | `8` | number | The maximum number of results to show in the results list. | Web, React Native |
@@ -36,7 +36,7 @@ Available options include:
 | `placeholder` | `Search address` | string | The placeholder string for the input. | Web, React Native |
 | `responsive` | `true` | boolean | A boolean that indicates whether the input should expand to fill the parent container. If `responsive = true` and a `width` is specified, `width` will be treated as a `max-width`. | Web |
 | `disabled` | `false` | boolean | A boolean that indicates whether the input should be disabled. | Web, React Native |
-| `layers` | `null` | array | Optional layer filters. An array including one or more of `place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, and `fine`. See the [autocomplete API documentation](https://radar.com/documentation/api#autocomplete) for more info. | Web, React Native |
+| `layers` | `null` | array | Optional layer filters. An array including one or more of `place`, `address`, `intersection`, `street`, `neighborhood`, `postalCode`, `locality`, `county`, `state`, `country`, `coarse`, and `fine`. See the [autocomplete API documentation](https://radar.com/api#autocomplete) for more info. | Web, React Native |
 | `countryCode` | `null` | string | An optional 2-letter [ISO 3166](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes) country code. If set, results will only be fetched from the specified country. | Web, React Native |
 | `expandUnits` | `false` | boolean | A boolean that indicates whether to include unit numbers in the results. | Web |
 | `showMarkers` | `true` | boolean | A boolean that indicates whether to show marker icons in the results list. | Web, React Native |
@@ -141,7 +141,7 @@ export const App = () => (
 
 ### Use Autocomplete with Radar Maps in React
 
-Below is an example of how you can use [Radar Maps](https://radar.com/documentation/maps/maps) with Radar Autocomplete in React.
+Below is an example of how you can use [Radar Maps](https://radar.com/maps/maps) with Radar Autocomplete in React.
 ```jsx
 import React, { useEffect, useRef } from 'react';
 import Radar from 'radar-sdk-js';

--- a/docs/maps/geocoding.mdx
+++ b/docs/maps/geocoding.mdx
@@ -12,7 +12,7 @@ Use Radar's geocoding APIs to convert addresses to latitude and longitude coordi
 
 First, [sign up](https://radar.com/signup) for Radar and get an API key.
 
-Then, call one of the geocoding APIs below, either [directly](/documentation/api) or [using the SDK](/documentation/sdk).
+Then, call one of the geocoding APIs below, either [directly]/api) or [using the SDK]/sdk).
 
 From there, use the APIs to build location features in your app or website, such as store locators, address autocomplete, or delivery tracking.
 
@@ -22,11 +22,11 @@ From there, use the APIs to build location features in your app or website, such
 
 Use the forward geocoding API to convert addresses to coordinates.
 
-This endpoint is best for complete addresses. For partial addresses, call the [autocomplete API](/documentation/maps/search#autocomplete) instead.
+This endpoint is best for complete addresses. For partial addresses, call the [autocomplete API]/maps/search#autocomplete) instead.
 
 Use cases for this endpoint include converting an address to coordinates to drop a pin on a map or search nearby the address.
 
-See the forward geocoding API reference [here](/documentation/api#forward-geocode).
+See the forward geocoding API reference [here]/api#forward-geocode).
 
 ### Reverse geocoding
 
@@ -34,7 +34,7 @@ Use the reverse geocoding API to convert coordinates to an address.
 
 Use cases for this endpoint include displaying an address for a pin dropped on a map.
 
-See the reverse geocoding API reference [here](/documentation/api#reverse-geocode).
+See the reverse geocoding API reference [here]/api#reverse-geocode).
 
 ### IP geocoding
 
@@ -42,7 +42,7 @@ Use the IP geocoding API to convert IP address to city, state, and country.
 
 Use cases for this endpoint include localizing content on a website or in an app without requesting location permissions.
 
-See the IP geocoding API reference [here](/documentation/api#ip-geocode).
+See the IP geocoding API reference [here]/api#ip-geocode).
 
 ## Coverage
 

--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -158,8 +158,8 @@ The minimum recommended options are the following:
 | Name  | Default | Possible values | Description           |
 |-------|---------|-----------------|-----------------------|
 | `container` | none (required) | string \| HTMLElement | The container to render the map into. You can specify an `id` of an HTML element or a DOM element. The width and height of this element will determine the size of the map. |
-| `style` | `radar-default-v1` | `radar-default-v1`, `radar-light-v1`, `radar-dark-v1` | The style of the map. See the [Styles](/documentation/maps/maps#styles) section below for more details. |
-| `center` | none (IP geolocation) | `[longitude, latitude]` | The center of the map. If not specified, the map will  automatically be centered based on the client's [IP geolocation](/documentation/api#ip-geocode). |
+| `style` | `radar-default-v1` | `radar-default-v1`, `radar-light-v1`, `radar-dark-v1` | The style of the map. See the [Styles]/maps/maps#styles) section below for more details. |
+| `center` | none (IP geolocation) | `[longitude, latitude]` | The center of the map. If not specified, the map will  automatically be centered based on the client's [IP geolocation]/api#ip-geocode). |
 | `zoom` | 11 | number | The zoom level of the map, a number between 0 (fully zoomed out) and 23 (fully zoomed in). |
 | `language` | none | string (ISO code) | This display language for map. Can be any 2-letter [ISO Code](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes), or `local` to use the device's specified language. Defaults to `en-US` if none is provided. |
 
@@ -190,8 +190,8 @@ The Radar map class also includes some additional functions for handling common 
 | `getFeatures` | none | RadarMapFeature[] | Returns an array of all features currently associated with the map. |
 | `fitToFeatures` | fitBoundsOptions | void | Fit the map zoom and bounds to all features on the map. |
 | `clearFeatures` | none | void | Remove all features from the map. |
-| `addPolygon` | GeoJSON<Polygon \| MultiPolygon> Feature, polygonOptions | RadarMapFeature | Add a new polygon [Feature](/documentation/maps/maps#polygon-and-multipolygon) to the map. |
-| `addLine` | GeoJSON<LineString\> Feature, lineOptions | RadarMapFeature | Add a new line [Feature](/documentation/maps/maps#line-and-polyline) to the map. |
+| `addPolygon` | GeoJSON<Polygon \| MultiPolygon> Feature, polygonOptions | RadarMapFeature | Add a new polygon [Feature]/maps/maps#polygon-and-multipolygon) to the map. |
+| `addLine` | GeoJSON<LineString\> Feature, lineOptions | RadarMapFeature | Add a new line [Feature]/maps/maps#line-and-polyline) to the map. |
 | `addPolyline` | encodedPolyline, polylineOptions | RadarMapFeature | Accepts an encoded polyline and converts it to a line feature. Defaults to six decimals precision. |
 
 ```javascript
@@ -273,7 +273,7 @@ Radar Marker's support all options in the MapLibre GL [marker options](https://m
 | Name  | Default | Possible values | Description           |
 |-------|---------|-----------------|-----------------------|
 | `color` | #000257 | string | Color of the default marker image. |
-| `marker` | none | string | ID of a marker uploaded as part of a [custom style](/documentation/tutorials/create-a-custom-map-style) |
+| `marker` | none | string | ID of a marker uploaded as part of a [custom style]/tutorials/create-a-custom-map-style) |
 | `url` | none | string | URL of image to use for the marker. |
 | `element` | none | HTMLElement | DOM element to be used as the marker. |
 | `width` | none | number | Size for marker width in pixels. |
@@ -788,7 +788,7 @@ export default RadarMap;
 
 ### Display a route
 
-Routes can be plotted on a Radar Map as a GeoJSON LineString, or an encoded polyline, both of which are formats provided by Radar's [routing APIs](/documentation/maps/routing).
+Routes can be plotted on a Radar Map as a GeoJSON LineString, or an encoded polyline, both of which are formats provided by Radar's [routing APIs]/maps/routing).
 
 Polylines can be added to the map with the `map.addPolyline` function, and accepts an optional precision value (defaults to 6). LineString's use the `map.addLine` function.
 

--- a/docs/maps/maps.mdx
+++ b/docs/maps/maps.mdx
@@ -243,7 +243,7 @@ Radar provides several out-of-the box map styles:
 
 #### Custom styles
 
-You can also <a href="/documentation/tutorials/create-a-custom-map-style">create a custom map style</a> with Radar Maps Studio. Maps Studio is a visual maps editor available in the Radar dashboard, and supports advanced maps customizations, custom fonts, and custom markers.
+You can also <a href="/tutorials/create-a-custom-map-style">create a custom map style</a> with Radar Maps Studio. Maps Studio is a visual maps editor available in the Radar dashboard, and supports advanced maps customizations, custom fonts, and custom markers.
 
 <table className="full-width-table">
   <thead>

--- a/docs/maps/migration-sdk.mdx
+++ b/docs/maps/migration-sdk.mdx
@@ -46,13 +46,13 @@ Additionally you can specify a callback and Radar map style which is defined bel
 | Name  | Default | Possible values | Description           |
 |-------|---------|-----------------|-----------------------|
 |`key` | none (required) | string | Your Radar publishable API key. |
-| `style` | `radar-default-v1` | `radar-default-v1`, `radar-light-v1`, `radar-dark-v1`, `CUSTOM_STYLE_ID` | The style of the map. One of Radar's out-of-the box styles, or a <a href="/documentation/maps/maps#custom-styles">custom style</a> ID. <br /><br />See [map styles](https://radar.com/documentation/maps/maps#styles) for more details. |
+| `style` | `radar-default-v1` | `radar-default-v1`, `radar-light-v1`, `radar-dark-v1`, `CUSTOM_STYLE_ID` | The style of the map. One of Radar's out-of-the box styles, or a <a href="/maps/maps#custom-styles">custom style</a> ID. <br /><br />See [map styles](https://radar.com/maps/maps#styles) for more details. |
 | `callback` | none | string | The name of a maps callback function to be called once the library is imported |
 </div>
 
 
 ## Coverage
-See [Maps coverage](https://radar.com/documentation/maps/maps#coverage) for more details.
+See [Maps coverage](https://radar.com/maps/maps#coverage) for more details.
 
 
 ## Support

--- a/docs/maps/overview.mdx
+++ b/docs/maps/overview.mdx
@@ -11,7 +11,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Radar Maps Platform is a cost-effective solution for geocoding APIs, search APIs, routing APIs, and base maps.
 
-Together with our [Geofencing Platform](/documentation/geofencing/overview), Radar provides full-stack location infrastructure for any product or service. We power location-based experiences for [enterprises and startups](https://radar.com/customers) across hundreds of millions of devices worldwide.
+Together with our [Geofencing Platform]/geofencing/overview), Radar provides full-stack location infrastructure for any product or service. We power location-based experiences for [enterprises and startups](https://radar.com/customers) across hundreds of millions of devices worldwide.
 
 ## Features
 

--- a/docs/maps/routing.mdx
+++ b/docs/maps/routing.mdx
@@ -12,7 +12,7 @@ Use Radar's routing APIs to calculate travel distances between origins and desti
 
 First, [sign up](https://radar.com/signup) for Radar and get an API key.
 
-Then, call one of the routing APIs below, either [directly](/documentation/api) or [using the SDK](/documentation/sdk).
+Then, call one of the routing APIs below, either [directly]/api) or [using the SDK]/sdk).
 
 From there, use the APIs to build location features in your app or website, such as store locators, address autocomplete, or delivery tracking.
 
@@ -24,7 +24,7 @@ Use the distance API to calculate the travel distance and duration between an or
 
 Use cases for this endpoint include calculating the distance and duration of a trip from point A to point B, calculating the ETA for a pickup or delivery, or calculating the walking and driving distance to a nearby store.
 
-See the distance API reference [here](/documentation/api#distance).
+See the distance API reference [here]/api#distance).
 
 ### Matrix
 
@@ -32,7 +32,7 @@ Use the matrix API to calculate travel distances and durations between multiple 
 
 Use cases for this endpoint include calculating the walking or driving distance to multiple nearby stores (e.g., in a store locator) or optimizing routes.
 
-See the matrix API reference [here](/documentation/api#matrix).
+See the matrix API reference [here]/api#matrix).
 
 ### Route matching
 
@@ -40,7 +40,7 @@ Use the route matching API to snap points collected along a route to roads that 
 
 Use cases for this endpoint include producing clean paths that can be displayed on a map, used for accurate mileage tracking and other analysis, as well as retrieving road context such as speed limits and road names along a traveled path.
 
-See the route matching API reference [here](/documentation/api#route-match).
+See the route matching API reference [here]/api#route-match).
 
 ### Directions
 
@@ -48,7 +48,7 @@ Use the directions API to calculate the most efficient route between two or more
 
 Use cases for this endpoint include calculating and displaying paths between locations on a map.
 
-See the directions API reference [here](/documentation/api#directions).
+See the directions API reference [here]/api#directions).
 
 ### Route optimization
 
@@ -56,7 +56,7 @@ Use the route optimization API to calculate the optimal ordering and route to vi
 
 Use cases for this endpoint include determining the best sequence for several pickups or deliveries, or calculating the optimal route to visit multiple stops.
 
-See the route optimization API reference [here](/documentation/api#optimize-route).
+See the route optimization API reference [here]/api#optimize-route).
 
 ## Coverage
 

--- a/docs/maps/search.mdx
+++ b/docs/maps/search.mdx
@@ -13,7 +13,7 @@ Use Radar's search APIs to search data in Radar, including addresses, places, an
 
 First, [sign up](https://radar.com/signup) for Radar and get an API key.
 
-Then, call one of the search APIs below, either [directly](/documentation/api) or [using the SDK](/documentation/sdk).
+Then, call one of the search APIs below, either [directly]/api) or [using the SDK]/sdk).
 
 From there, use the APIs to build location features in your app or website, such as store locators, address autocomplete, or delivery tracking.
 
@@ -23,11 +23,11 @@ From there, use the APIs to build location features in your app or website, such
 
 Use the address autocomplete API to autocomplete partial addresses.
 
-This endpoint is best for partial addresses. For complete addresses, call the [forward geocoding API](/documentation/maps/geocoding#forward) instead.
+This endpoint is best for partial addresses. For complete addresses, call the [forward geocoding API]/maps/geocoding#forward) instead.
 
 Use cases for this endpoint include autocompleting partial addresses for checkout forms or store locators.
 
-See the autocomplete API reference [here](/documentation/api#autocomplete).
+See the autocomplete API reference [here]/api#autocomplete).
 
 ### Address validation
 
@@ -35,15 +35,15 @@ Use the address validation API to validate complete structured addresses.
 
 Use cases for this endpoint include verifying addresses or suggesting mailable addresses for checkout forms or delivery.
 
-See the address validation API reference [here](/documentation/api#validate-an-address).
+See the address validation API reference [here]/api#validate-an-address).
 
 ### Places search
 
-Use the places search API to search for places near a location, filtered by [chain](/documentation/places#chains) (e.g., `mcdonalds`) or [category](/documentation/places#categories) (e.g., `airport`).
+Use the places search API to search for places near a location, filtered by [chain]/places#chains) (e.g., `mcdonalds`) or [category]/places#categories) (e.g., `airport`).
 
 Use cases for this endpoint include nearby search.
 
-See the places search API reference [here](/documentation/api#search-places).
+See the places search API reference [here]/api#search-places).
 
 ### Geofences search
 
@@ -51,7 +51,7 @@ Use the geofences search API to search for geofences near a location, filtered b
 
 Use cases for this endpoint include store locators, assuming you've imported your stores as geofences.
 
-See the geofences search API reference [here](/documentation/api#search-geofences).
+See the geofences search API reference [here]/api#search-geofences).
 
 ## Coverage
 

--- a/docs/maps/static-maps.mdx
+++ b/docs/maps/static-maps.mdx
@@ -35,7 +35,7 @@ Static Map images can be used inline with HTML `<img>` tags by setting the `src`
 | `center` | none (required, unless markers are provided) | string | The coordinates specified in `latitude,longitude` format for the center of the map. If `center` is not provided then the map will be centered to visibly fit all markers in view.|
 | `zoom` | none (required, unless bbox, markers, or path are provided) | number | The `zoom` position of the map which is a number between `1` and `23`. If `zoom` is not provided then the map will fit the view to the markers. |
 | `scale` | 1 | number | The scale or resolution of the map as a number between `1` and `3`. This is useful for high-density displays and will affect the width and height parameters by returning an image that is the product of the width/height and scale. |
-| `style` | `radar-default-v1` | `radar-default-v1`, `radar-light-v1`, `radar-dark-v1`, `CUSTOM_STYLE_ID` | The style of the map. One of Radar's out-of-the box styles, or a <a href="/documentation/maps/maps#custom-styles">custom style</a> ID. <br /><br />See [map styles](https://radar.com/documentation/maps/maps#styles) for more details. |
+| `style` | `radar-default-v1` | `radar-default-v1`, `radar-light-v1`, `radar-dark-v1`, `CUSTOM_STYLE_ID` | The style of the map. One of Radar's out-of-the box styles, or a <a href="/maps/maps#custom-styles">custom style</a> ID. <br /><br />See [map styles](https://radar.com/maps/maps#styles) for more details. |
 | `bbox` | none | string | The bbox or latitude and longitude bounds of the image. Specified as `min_latitude,min_longitude,max_latitude,max_longitude`. The image returned will fit the specified bounding box. |
 | `markers` | none | string | For rendering markers on the map. See [markers](#markers) for more details. |
 | `path` | none | string | For rendering paths on the map. See [paths](#paths) for more details. |
@@ -150,7 +150,7 @@ Note: images will be capped at 64 x 64 pixels.
 
 ### Rendering a route
 
-Radar [Routing API](/documentation/api#routing) responses include the shape of the route in either the polyine or LineString format. Both of these formats are supported for rendering a path, which can be used to plot the route in a static image.
+Radar [Routing API]/api#routing) responses include the shape of the route in either the polyine or LineString format. Both of these formats are supported for rendering a path, which can be used to plot the route in a static image.
 
 <StaticMap
   query='width=900&height=600&style=radar-light-v1&scale=2&markers=size:small|icon:https://radar.com/static/image/maps/map-pin-origin@3x.png|40.70425,-73.9865&markers=size:small|icon:https://radar.com/static/image/maps/map-pin-destination@3x.png|40.73412,-73.99128&path=borderwidth:2|border:0xFFFFFF|width:3|stroke:0x000257|enc:g{rwFnlrbMkArDENGRiCfIEJCJHFpA|@VPHFDOBGdC_IFQDO|BiHHUJBb@FxARLBH@l@HbANB?LDJF@@vAfAJHHF|AnAHFHHhA|@RNJJ|@r@LJJFHHh@`@p@h@JJJF~ApAJHFFzAlADDHFJHbAx@^XJHHHrB~ADDBBJFl@f@@@ZVb@%08Av@LJVRBURsAN}@BQ@K?AN_AFWDUPq@BMBKj@wBBMDMh@sBBMBMTy@Pu@BIDQPDd@NnATtBh@`@Ll@NJBD@`Cl@HBFBjBj@D@JBHBTFx@TJDVFTF`@LZAnA`@JBJDlDfALDLD~@`@fAd@hAf@JFHDjBbAJD@@LFj@ZJFVLZQtA}@ZUHGJKHKV]HKFIHIFGJIHGLILGjAg@t|Aks@H?JCJCRIFEHCHCH?FAF@F@HBFDFHDHBJ@L@JALAJCHEFEHE@C@C@I@I?I@G@I@KAc@AeACy@AG?I@KBODIBGBOF}@b@OFBgA?IM?Q?_@Ai@Cs@AI?I@K?yCKK?MAsAC_@AG?IAmBEI?[A'
@@ -195,7 +195,7 @@ https://api.radar.io/maps/static?width=200&height=200&center=40.71257,-74.00260&
 </table>
 
 ## Coverage
-See [Maps coverage](https://radar.com/documentation/maps/maps#coverage) for more details.
+See [Maps coverage](https://radar.com/maps/maps#coverage) for more details.
 
 
 ## Support

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -12,9 +12,9 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 [Radar](https://radar.com) is full-stack location infrastructure for every product and service. Our [SDKs](/sdk) and [APIs](/api) make it easy to add location-based experiences to your app or website, from pickup and delivery tracking to location-based messaging to store locators and more.
 
-Our [Geofencing Platform](/documentation/geofencing/overview) is the industry-leading geofencing and location tracking platform, including geofencing, place visit detection, trip tracking, fraud detection, and analytics.
+Our [Geofencing Platform]/geofencing/overview) is the industry-leading geofencing and location tracking platform, including geofencing, place visit detection, trip tracking, fraud detection, and analytics.
 
-Our [Maps Platform](/documentation/maps/overview) is a cost-effective solution for geocoding APIs, search APIs, routing APIs, and base maps.
+Our [Maps Platform]/maps/overview) is a cost-effective solution for geocoding APIs, search APIs, routing APIs, and base maps.
 
 We power location-based experiences for [enterprises and startups](https://radar.com/customers) across hundreds of millions of devices worldwide.
 

--- a/docs/places.mdx
+++ b/docs/places.mdx
@@ -59,7 +59,7 @@ First, [sign up](https://radar.com/signup) for Radar and get an API key.
 
 Then, enable Places events and enable chains or categories on the [Settings page](https://radar.com/dashboard/settings).
 
-From there, [integrate the SDK](/documentation/sdk) and call `Radar.trackOnce()` or `Radar.startTracking()`, depending on your use case. Radar will generate an entry event on the first stopped location update at a place matching your enabled chains or categories.
+From there, [integrate the SDK]/sdk) and call `Radar.trackOnce()` or `Radar.startTracking()`, depending on your use case. Radar will generate an entry event on the first stopped location update at a place matching your enabled chains or categories.
 
 ## How it works
 

--- a/docs/regions.mdx
+++ b/docs/regions.mdx
@@ -57,7 +57,7 @@ First, [sign up](https://radar.com/signup) for Radar and get an API key.
 
 Then, enable Regions events on the [Settings page](https://radar.com/dashboard/settings).
 
-From there, [integrate the SDK](/documentation/sdk) and call `Radar.trackOnce()` or `Radar.startTracking()`, depending on your use case. Radar will generate an entry event on the first location update in a region matching your enabled event types.
+From there, [integrate the SDK]/sdk) and call `Radar.trackOnce()` or `Radar.startTracking()`, depending on your use case. Radar will generate an entry event on the first location update in a region matching your enabled event types.
 
 ## Countries
 

--- a/docs/sdk/android.mdx
+++ b/docs/sdk/android.mdx
@@ -984,7 +984,7 @@ Finally, to set an optional description for the user, displayed in the dashboard
 
 You only need to call these methods once, as these settings will be persisted across app sessions.
 
-Learn more about when Radar creates new user records [here](/documentation/faqs#what-is-a-unique-user-when-does-radar-create-a-new-user-record).
+Learn more about when Radar creates new user records [here]/faqs#what-is-a-unique-user-when-does-radar-create-a-new-user-record).
 
 ## Debug logging
 

--- a/docs/sdk/ios.mdx
+++ b/docs/sdk/ios.mdx
@@ -1105,7 +1105,7 @@ Radar.setDescription(description)
 
 You only need to call these methods once, as these settings will be persisted across app sessions.
 
-Learn more about when Radar creates new user records [here](/documentation/faqs#what-is-a-unique-user-when-does-radar-create-a-new-user-record).
+Learn more about when Radar creates new user records [here]/faqs#what-is-a-unique-user-when-does-radar-create-a-new-user-record).
 
 ## Debug logging
 

--- a/docs/sdk/react-native.mdx
+++ b/docs/sdk/react-native.mdx
@@ -737,7 +737,7 @@ iOS defaults to the standard notification icon.
 
 ### Maps and UI kits
 
-The React Native SDK also has UI components for maps and address autocomplete. Learn more in the [Maps Platform documentation](/documentation/maps/overview).
+The React Native SDK also has UI components for maps and address autocomplete. Learn more in the [Maps Platform documentation]/maps/overview).
 
 ## Support
 

--- a/docs/sdk/web.mdx
+++ b/docs/sdk/web.mdx
@@ -100,7 +100,7 @@ where `description` is a string.
 
 You only need to call these functions once, as these settings will be persisted across browser sessions.
 
-Learn more about when Radar creates new user records [here](/documentation/faqs#what-is-a-unique-user-when-does-radar-create-a-new-user-record).
+Learn more about when Radar creates new user records [here]/faqs#what-is-a-unique-user-when-does-radar-create-a-new-user-record).
 
 ### Foreground tracking
 
@@ -379,7 +379,7 @@ Radar.matrix({
 
 ## Maps and UI kits
 
-The React Native SDK also has UI components for maps and address autocomplete. Learn more in the [Maps Platform documentation](/documentation/maps/overview).
+The React Native SDK also has UI components for maps and address autocomplete. Learn more in the [Maps Platform documentation]/maps/overview).
 
 ## Support
 

--- a/docs/trip-tracking.mdx
+++ b/docs/trip-tracking.mdx
@@ -65,9 +65,9 @@ Trips also provides the following events:
 
 First, [sign up](https://radar.com/signup) for Radar and get an API key.
 
-Then, [create a destination geofence](/documentation/geofences#create-a-geofence).
+Then, [create a destination geofence]/geofences#create-a-geofence).
 
-From there, [integrate the SDK](/documentation/sdk) and call `Radar.startTrip()`. Radar will generate trip events with ETAs to the destination geofence.
+From there, [integrate the SDK]/sdk) and call `Radar.startTrip()`. Radar will generate trip events with ETAs to the destination geofence.
 
 ## Starting trips
 
@@ -355,7 +355,7 @@ Radar calculates ETAs and generates events when trips are updated:
 - `user.arrived_at_trip_destination` (destination geofence entered)
 - `user.stopped_trip`
 
-ETAs are calculated based on travel mode using the same routing engine that powers our [distance API](/documentation/maps/routing).
+ETAs are calculated based on travel mode using the same routing engine that powers our [distance API]/maps/routing).
 
 You can receive events client-side via the [SDK](/sdk) or server-side via [event integrations](/integrations), including webhooks.
 

--- a/docs/tutorials/building-menuboard-detection-with-in-geofence-tracking-options.mdx
+++ b/docs/tutorials/building-menuboard-detection-with-in-geofence-tracking-options.mdx
@@ -176,7 +176,7 @@ class MainActivity : AppCompatActivity() {
 
 }
 ```
-Because we'll be using the `continuous` preset and a foreground service, make sure you include the `FOREGROUND_SERVICE_LOCATION` permission in your [manifest](/documentation/sdk/android#request-permissions).
+Because we'll be using the `continuous` preset and a foreground service, make sure you include the `FOREGROUND_SERVICE_LOCATION` permission in your [manifest]/sdk/android#request-permissions).
 
   </TabItem>
     <TabItem value="react-native">

--- a/docs/tutorials/create-a-custom-map-style.mdx
+++ b/docs/tutorials/create-a-custom-map-style.mdx
@@ -42,7 +42,7 @@ To upload a custom marker, click the <b>+</b> button where it says "Add a marker
 </video>
 
 <br /><br />
-See the <a href="/documentation/maps/maps#marker">marker</a> section of the Maps docs for more info on using custom markers.
+See the <a href="/maps/maps#marker">marker</a> section of the Maps docs for more info on using custom markers.
 
 
 ## Advanced mode

--- a/docs/tutorials/migrate-from-google-maps.mdx
+++ b/docs/tutorials/migrate-from-google-maps.mdx
@@ -7,54 +7,54 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Alert from "../../src/components/Alert";
 
-Migrating from Google Maps to the [Radar Maps Platform](https://radar.com/documentation/maps/overview) is simple, and usually involves just a few lines of code. Find the Google Maps offerings used in your application below and learn about the corresponding cost-effective, developer-friendly Radar alternative.
+Migrating from Google Maps to the [Radar Maps Platform](https://radar.com/maps/overview) is simple, and usually involves just a few lines of code. Find the Google Maps offerings used in your application below and learn about the corresponding cost-effective, developer-friendly Radar alternative.
 
 
 ### Maps
-Google's maps offering is used for rendering maps in applications. Radar provides vector [base maps](https://radar.com/documentation/maps/maps) with beautiful out-of-the-box styles as an alternative. Check out the [maps explorer](https://radar.com/dashboard/maps/maps-explorer/maps) in the dashboard to see them in action.
+Google's maps offering is used for rendering maps in applications. Radar provides vector [base maps](https://radar.com/maps/maps) with beautiful out-of-the-box styles as an alternative. Check out the [maps explorer](https://radar.com/dashboard/maps/maps-explorer/maps) in the dashboard to see them in action.
 
 <div className="full-width-table">
 
 | Google Maps Feature | Radar Feature
 -------------------------------------|--------------------------------------------------------------------------------|
-| Dynamic Maps | [Dynamic Maps](/documentation/maps/maps)
-| Static Maps | [Static Maps](/documentation/maps/static-maps)
+| Dynamic Maps | [Dynamic Maps]/maps/maps)
+| Static Maps | [Static Maps]/maps/static-maps)
 
 </div>
 
 ### Places
 
-Google's Places APIs enable finding and geocoding locations such as addresses and points of interest. Radar's [Geocoding and Search APIs](https://radar.com/documentation/maps/geocoding) provide fully featured geocoding, autocomplete, address validation, and geolocation APIs as an alternative.
+Google's Places APIs enable finding and geocoding locations such as addresses and points of interest. Radar's [Geocoding and Search APIs](https://radar.com/maps/geocoding) provide fully featured geocoding, autocomplete, address validation, and geolocation APIs as an alternative.
 
 <div className="full-width-table">
 
 | Google Maps API | Radar API |
 -------------------------------------|--------------------------------------------------------------------------------|
-| Geocoding API   | [Forward Geocoding API](/documentation/api#forward-geocode)              |
-| Reverse Geocoding API  | [Reverse Geocoding API](/documentation/api#reverse-geocode)           |
-| N/A | [IP Geocoding API](/documentation/api#ip-geocode)             |
-| Autocomplete API   | [Autocomplete API](/documentation/api#autocomplete)              |
-| Place Autocomplete UI | [Autocomplete Component](/documentation/maps/autocomplete)
-| Address Validation API | [Address Validation API](/documentation/api#validate-an-address)     |
-| Nearby Search API   | [Places Search API](/documentation/api#search-places)             |
-| Current Place API   | [Context API](/documentation/api#context)             |
+| Geocoding API   | [Forward Geocoding API]/api#forward-geocode)              |
+| Reverse Geocoding API  | [Reverse Geocoding API]/api#reverse-geocode)           |
+| N/A | [IP Geocoding API]/api#ip-geocode)             |
+| Autocomplete API   | [Autocomplete API]/api#autocomplete)              |
+| Place Autocomplete UI | [Autocomplete Component]/maps/autocomplete)
+| Address Validation API | [Address Validation API]/api#validate-an-address)     |
+| Nearby Search API   | [Places Search API]/api#search-places)             |
+| Current Place API   | [Context API]/api#context)             |
 
 
 </div>
 
 ### Routes
 
-Google's Routes APIs are used to calculate routes between locations or snap to roads. Radar's [routing APIs](https://radar.com/documentation/maps/routing) provide a suite of distance, matrix, directions, route match, and optimize APIs to power these use cases and more.
+Google's Routes APIs are used to calculate routes between locations or snap to roads. Radar's [routing APIs](https://radar.com/maps/routing) provide a suite of distance, matrix, directions, route match, and optimize APIs to power these use cases and more.
 
 <div className="full-width-table">
 
 | Google Maps API | Radar API
 -------------------------------------|--------------------------------------------------------------------------------|
-| Distance Matrix API | [Distance Matrix API](/documentation/api#matrix)
-| Directions API | [Directions API](/documentation/api#directions)
-| Snap to Roads API | [Route Matching API](/documentation/api#route-match)
-| Speed Limits API | [Route Matching API](/documentation/api#route-match), with `speedLimit` included in the `roadAttributes` parameter
-| Compute Routes API | [Matrix API](/documentation/api#matrix), [Directions API](/documentation/api#directions), or [Route Optimization API](/documentation/api#optimize-route)
+| Distance Matrix API | [Distance Matrix API]/api#matrix)
+| Directions API | [Directions API]/api#directions)
+| Snap to Roads API | [Route Matching API]/api#route-match)
+| Speed Limits API | [Route Matching API]/api#route-match), with `speedLimit` included in the `roadAttributes` parameter
+| Compute Routes API | [Matrix API]/api#matrix), [Directions API]/api#directions), or [Route Optimization API]/api#optimize-route)
 
 </div>
 

--- a/docs/waypoint.mdx
+++ b/docs/waypoint.mdx
@@ -49,7 +49,7 @@ To get started, you'll need a Radar account. Don't have a Radar account yet? [Si
 
 6. To track in the background, move more than 100 meters! **Note that location updates may be delayed significantly by Android [Doze Mode and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby.html), iOS [Low Power Mode](https://support.apple.com/en-us/HT205234), or if the device has connectivity issues, low battery, or wi-fi disabled.**
 
-7. To try out different presets, open the *Settings* screen. Then, select the *Tracking Options* preset to use, one of *Efficient*, *Responsive*, or *Continuous*. Learn about [iOS tracking presets](/sdk/tracking#ios-presets) and [Android tracking presets](/sdk/tracking#android-presets). You can also set *Custom Tracking Options* via [Remote SDK Configurations](https://radar.com/documentation/sdk/remote-configuration). Manage the notifications you want to receive, including *Events* (events received from Radar), *Locations* (location updates sent to Radar), and *Errors* (network, location, and permissions errors).
+7. To try out different presets, open the *Settings* screen. Then, select the *Tracking Options* preset to use, one of *Efficient*, *Responsive*, or *Continuous*. Learn about [iOS tracking presets](/sdk/tracking#ios-presets) and [Android tracking presets](/sdk/tracking#android-presets). You can also set *Custom Tracking Options* via [Remote SDK Configurations](https://radar.com/sdk/remote-configuration). Manage the notifications you want to receive, including *Events* (events received from Radar), *Locations* (location updates sent to Radar), and *Errors* (network, location, and permissions errors).
 
 <div style={{ display: 'flex', justifyContent: 'space-between', padding: '0 55px' }}>
   <img src={useBaseUrl("/img/waypointAndroid.png")} />
@@ -61,7 +61,7 @@ To get started, you'll need a Radar account. Don't have a Radar account yet? [Si
 
 1. To get started, make sure you've opted-in to foreground or "while in use" permissions and notifications are enabled. Click on the settings icon on the top right to ensure Waypoint is configured correctly (See image A below).
 
-2. Create [geofences](https://radar.com/documentation/geofences#dashboard) in Radar.
+2. Create [geofences](https://radar.com/geofences#dashboard) in Radar.
 
 3. Open Waypoint and navigate to the "My Location" tab. You should see "Not in a geofence". Travel to a configured geofence (See image B below).
 
@@ -88,7 +88,7 @@ To get started, you'll need a Radar account. Don't have a Radar account yet? [Si
 
 1. To get started, make sure you've opted-in to foreground or "While in use" permissions and notifications are enabled. (See image A below)
 
-2. Create [geofences](https://radar.com/documentation/geofences#dashboard) in Radar.
+2. Create [geofences](https://radar.com/geofences#dashboard) in Radar.
 
 3. Once you open Waypoint, you should see geofences nearby you. Click "Go" to start a trip to one of the configured geofences. Select your mode of travel from the options provided. Start navigating to your destination geofence. (See image B below)
 
@@ -139,7 +139,7 @@ To get started, you'll need a Radar account. Don't have a Radar account yet? [Si
 ### Testing Background Mode
 1. To get started, make sure you've opted-in to background or "Always allow" permissions and notifications are enabled. You'll have to navigate to your device settings to enable background tracking and toggle the "Background tracking" option in Waypoint. Click on the settings icon on the top right to ensure Waypoint is configured correctly. (See image A below)
 
-2. Create [geofences](https://radar.com/documentation/geofences#dashboard) in Radar.
+2. Create [geofences](https://radar.com/geofences#dashboard) in Radar.
 
 3. Open Waypoint and navigate to "My Location" tab. You should see "Not in a geofence". Travel to a configured geofence. (See image B below)
 
@@ -168,9 +168,9 @@ Note: You can test beacons in either foreground or background mode.
   * Opt-in to foreground or background permissions.
   * Ensure notifications are enabled.
   * Once you click on the settings icon on the top right, you can toggle "Beacons" on. This should prompt you to allow Bluetooth permissions. 
-     Alternatively, use [remote SDK configuration](https://radar.com/documentation/sdk/remote-configuration) & set *beacons* to *true*. Once done, you should see the "Beacons" toggle enabled within the Waypoint settings page.
+     Alternatively, use [remote SDK configuration](https://radar.com/sdk/remote-configuration) & set *beacons* to *true*. Once done, you should see the "Beacons" toggle enabled within the Waypoint settings page.
 
-2. Create [beacons](https://radar.com/documentation/beacons) in Radar.
+2. Create [beacons](https://radar.com/beacons) in Radar.
 
 3. Open Waypoint and navigate to "My Location" tab. You should see "No Beacons Found". (See image B below)
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -140,7 +140,7 @@ module.exports = {
                     }
                     radarGitHubReleases[`RADAR_${sdkName.toUpperCase()}_SDK_VERSION`] = versionNumber;
                 }
-                
+
                 // get android sdk version that the flutter sdk uses from the build.gradle file
                 const response = await fetch(`https://raw.githubusercontent.com/radarlabs/flutter-radar/refs/tags/${radarGitHubReleases.RADAR_FLUTTER_SDK_VERSION}/android/build.gradle`)
                 const build_gradle = await response.text();
@@ -183,8 +183,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl:
-            'https://github.com/radarlabs/docs/edit/main/',
+          editUrl: 'https://github.com/radarlabs/docs/edit/main/',
           routeBasePath: '/',
         },
         theme: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@ module.exports = {
   title: 'Documentation | Radar',
   tagline: 'Location data infrastructure | Geofencing SDK and API',
   url: 'https://radar.com',
-  baseUrl: '/documentation/',
+  baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,8 @@
 {
-  "rewrites": [
-    { "source": "/documentation/:asset*", "destination": "/:asset*" }
-  ],
   "redirects": [
-    { "source": "/", "destination": "/documentation/", "permanent": true },
-    { "source": "/documentation/troubleshooting", "destination": "/documentation/geofencing/testing", "permanent": true },
-    { "source": "/documentation/places/groups", "destination": "/documentation/places", "permanent": true },
-    { "source": "/documentation/sdk/xamarin", "destination": "/documentation/sdk/maui", "permanent": true }
+    { "source": "/troubleshooting", "destination": "/geofencing/testing", "permanent": true },
+    { "source": "/places/groups", "destination": "/places", "permanent": true },
+    { "source": "/sdk/xamarin", "destination": "/sdk/maui", "permanent": true }
   ],
   "trailingSlash": false
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "redirects": [
     { "source": "/troubleshooting", "destination": "/geofencing/testing", "permanent": true },
     { "source": "/places/groups", "destination": "/places", "permanent": true },
-    { "source": "/sdk/xamarin", "destination": "/sdk/maui", "permanent": true }
+    { "source": "/sdk/xamarin", "destination": "/sdk/maui", "permanent": true },
+    { "source": "/documentation/:path*", "destination": "/:path*", "permanent": true }
   ],
   "trailingSlash": false
 }


### PR DESCRIPTION
Drops the `/documentation` prefix from all pages