### PR TITLE
Update rate limits for API endpoints, remove mailable param

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -440,7 +440,7 @@ Publishable
 
 ###### Default rate limit
 
-1000 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 ###### Sample request
 
@@ -512,7 +512,7 @@ Publishable
 
 ###### Default rate limit
 
-1000 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 ###### Sample request
 
@@ -640,7 +640,6 @@ Autocompletes partial addresses and place names, sorted by relevance and proximi
 - **`limit`** (number, optional): The max number of addresses to return. A number between 1 and 100. Defaults to 10.
 - **`countryCode`** (string, optional): An optional countries filter. A string of comma-separated countries, the unique 2-letter [country code](/regions/countries).
 - **`lang`** (string, optional): Specifies the language for the results. A string, one of `ar`, `de`, `en`, `es`, `fr`, `ja`, `ko`, `pt`, `ru`, `zh`. Defaults to `en`.
-- **`mailable`** (boolean, optional): Returns validated addresses. Only available for US and Canada addresses for enterprise customers.
 
 ###### Query best practices
 **US/CA:** For customers using autocomplete for full address completion (i.e. checkout page), pass in **`layers`**:  `address`, **`countryCode`**:  `US, CA`. 
@@ -653,7 +652,7 @@ Publishable
 
 ###### Default rate limit
 
-1000 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 ###### Sample request
 
@@ -1160,7 +1159,7 @@ Publishable
 
 ###### Default rate limit
 
-1000 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 ###### Sample request
 
@@ -1319,7 +1318,7 @@ Publishable
 
 ###### Default rate limit
 
-1000 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 ###### Sample request
 
@@ -2309,7 +2308,7 @@ Publishable
 
 ###### Default rate limit
 
-1000 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 ###### Sample request
 


### PR DESCRIPTION
## What?
Updating the rate limits for certain API endpoints, removing `mailable` param from autocomplete