### PR TITLE
docs: clarify input element container incompatibility in React

### DIFF
--- a/docs/maps/autocomplete.mdx
+++ b/docs/maps/autocomplete.mdx
@@ -201,3 +201,6 @@ const RadarMap = () => {
 
 export default RadarMap;
 ```
+
+Note that using an `<input/>` element reference as the `container` argument is not compatible with React since the parent
+element is mutated. You must use a non-input `container` reference when using React.


### PR DESCRIPTION
## What?

Wasted time debugging radar autocomplete with react :)

## Why?

The docs did not make it clear that the `<input/>` reference is not compatible with React.

## How?
doc change

## Screenshots (optional)
NA

## Anything Else? (optional)
I've written a ShadCN library for Radar. Can it be included in the documentation in some way?

https://github.com/iloveitaly/shadcn-radar-address-autocomplete
